### PR TITLE
fix: added dependency on build for sync targets

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -19,6 +19,9 @@
     }
   },
   "targetDefaults": {
+    "sync": {
+      "dependsOn": ["^build"]
+    },
     "build": {
       "dependsOn": [
         "^build"


### PR DESCRIPTION
### Description

Previously `sync` target did not invoke `build` of it's dependency projects and as a result it would fail if those projects were not built beforehand