### PR TITLE
fix: fixed problems with executor resolution in yarn workspaces

### DIFF
--- a/libs/webcomponents-nx/src/executors/sync/executor.js
+++ b/libs/webcomponents-nx/src/executors/sync/executor.js
@@ -1,0 +1,8 @@
+// @filename executor.js
+// @see https://github.com/nrwl/nx/issues/9823#issuecomment-1207397040
+const { workspaceRoot } = require('nx/src/utils/workspace-root');
+const { registerTsProject } = require('nx/src/utils/register');
+
+registerTsProject(workspaceRoot, 'tsconfig.base.json');
+
+module.exports = require('./executor.ts');


### PR DESCRIPTION
## Description
After the introduction of Lerna, we had to use yarn workspaces and since we have a custom plugin for certain things, executors would not resolve properly(they needed `.js` extension), this small fix does the trick.

More info can be found here
https://github.com/nrwl/nx/issues/9823