### PR TITLE
refactor: using relativePathFrom

### DIFF
--- a/libs/angular-generator/src/lib/theming-generator.ts
+++ b/libs/angular-generator/src/lib/theming-generator.ts
@@ -10,14 +10,14 @@ export function themingGenerator() {
     themingModuleFileName: 'ui5-theming.module',
     themingServiceFileName: 'ui5-theming.service'
   }
-  const themingModule = new Ui5GlobalThemingModule(config);
-  const themingService = new Ui5GlobalThemingService(config);
-  const themignModels = new Ui5ThemingModels(config);
-  const indexFile = new IndexFile([themingModule, themingService, themignModels]);
+  const themingModels = new Ui5ThemingModels(config);
+  const themingService = new Ui5GlobalThemingService(config, themingModels);
+  const themingModule = new Ui5GlobalThemingModule(config, themingService, themingModels);
+  const indexFile = new IndexFile([themingModule, themingService, themingModels]);
   return {
     indexFile,
     themingModule,
     themingService,
-    themignModels
+    themingModels
   };
 }

--- a/libs/angular-generator/src/lib/theming/theming-module.ts
+++ b/libs/angular-generator/src/lib/theming/theming-module.ts
@@ -1,9 +1,11 @@
 import { ExportSpecifierType, GeneratedFile } from "@ui5/webcomponents-wrapper";
 import { format } from "prettier";
 import { ThemingConfig } from "./theming-config.interface";
+import { Ui5GlobalThemingService } from "./theming-service";
+import { Ui5ThemingModels } from "./theming-models";
 
 export class Ui5GlobalThemingModule extends GeneratedFile {
-  constructor(public config: ThemingConfig) {
+  constructor(public config: ThemingConfig, private themingService: Ui5GlobalThemingService, private themingModels: Ui5ThemingModels) {
     super();
     this.move(`${this.config.themingModuleFileName}.ts`);
     this.initializeImportsAndExports();
@@ -16,8 +18,8 @@ export class Ui5GlobalThemingModule extends GeneratedFile {
       types: [ExportSpecifierType.Class],
     });
     this.addImport(['NgModule', 'ModuleWithProviders', 'Optional', 'isDevMode'], '@angular/core');
-    this.addImport(['Ui5ThemingService'], `./${this.config.themingServiceFileName}`);
-    this.addImport(['ThemingConfig', 'UI5_THEMING_CONFIGURATION'], `./${this.config.themingModelsFileName}`);
+    this.addImport(['Ui5ThemingService'], this.themingService.relativePathFrom);
+    this.addImport(['ThemingConfig', 'UI5_THEMING_CONFIGURATION'], this.themingModels.relativePathFrom);
   }
 
   override getCode(): string {

--- a/libs/angular-generator/src/lib/theming/theming-service.ts
+++ b/libs/angular-generator/src/lib/theming/theming-service.ts
@@ -1,9 +1,10 @@
 import { ExportSpecifierType, GeneratedFile } from "@ui5/webcomponents-wrapper";
 import { format } from "prettier";
 import { ThemingConfig } from "./theming-config.interface";
+import { Ui5ThemingModels } from "./theming-models";
 
 export class Ui5GlobalThemingService extends GeneratedFile {
-  constructor(public config: ThemingConfig) {
+  constructor(public config: ThemingConfig, private themingModels: Ui5ThemingModels) {
     super();
     this.move(`${this.config.themingServiceFileName}.ts`);
     this.initializeImportsAndExports();
@@ -16,7 +17,7 @@ export class Ui5GlobalThemingService extends GeneratedFile {
       types: [ExportSpecifierType.Class],
     });
     this.addImport(['Inject', 'Injectable', 'isDevMode'], '@angular/core');
-    this.addImport(['AvailableThemes', 'ThemingConfig', 'UI5_THEMING_CONFIGURATION', 'Ui5ThemingProvider', 'Ui5ThemingConsumer'], `./${this.config.themingModelsFileName}`);
+    this.addImport(['AvailableThemes', 'ThemingConfig', 'UI5_THEMING_CONFIGURATION', 'Ui5ThemingProvider', 'Ui5ThemingConsumer'], this.themingModels.relativePathFrom);
   }
 
   override getCode(): string {

--- a/libs/angular-generator/src/lib/webcomponents-theming.ts
+++ b/libs/angular-generator/src/lib/webcomponents-theming.ts
@@ -19,13 +19,13 @@ export class WebcomponentsThemingGenerator {
   }
 
   constructor() {
-    this.module = new WebcomponentsThemingModule(this.config);
     this.service = new WebcomponentsThemingService(this.config);
+    this.module = new WebcomponentsThemingModule(this.config, this.service);
   }
 }
 
 export class WebcomponentsThemingModule extends GeneratedFile<AngularExportSpecifierType> {
-  constructor(public config: ThemingGeneratorConfig) {
+  constructor(public config: ThemingGeneratorConfig, private service: WebcomponentsThemingService) {
     super();
     this.move(`${this.config.themingPath}/${this.config.themingModuleFileName}.ts`);
     this.initializeImportsAndExports();
@@ -44,7 +44,7 @@ export class WebcomponentsThemingModule extends GeneratedFile<AngularExportSpeci
     );
     this.addImport(
       ['Ui5WebcomponentsThemingService'],
-      `./${this.config.themingServiceFileName}`
+      this.service.relativePathFrom
     );
   }
 


### PR DESCRIPTION
## Description

This way, if the user renames generated files AFTER generation and BEFORE fs commit, actual generated files will have correct relations between them(correct relative paths)