### PR TITLE
fix: swapped github-actions with secrets-configured account

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -21,11 +21,12 @@ jobs:
         with:
           ref: ${{ fromJSON('["tmp_hotfix_branch", "main"]')[env.IS_HOTFIX] }}
           fetch-depth: 0
+          token: ${{ secrets.GH_TOKEN }}
 
       - name: Set up git user
         run: |
-          git config --global user.email "github-actions"
-          git config --global user.name "github-actions@github.com"
+          git config --global user.email "${{ secrets.GH_EMAIL }}"
+          git config --global user.name "${{ secrets.GH_NAME }}"
 
       - name: Setup Node.js and Cache
         uses: ./.github/actions/nodejs


### PR DESCRIPTION
## Description

Using secrets-configured user for git configurations instead of hardcoded github-actions user
