### PR TITLE
feat: i18n schematic

### DIFF
--- a/libs/angular-generator/src/lib/schematics/common-schematics/add-theming/index.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/add-theming/index.ts
@@ -1,8 +1,9 @@
-import {updateWorkspace} from '@schematics/angular/utility/workspace';
-import {Change, InsertChange} from '@schematics/angular/utility/change';
-import {Rule, SchematicsException} from '@angular-devkit/schematics';
-import {Schema} from '../schema';
-import {addThemingModule} from './add-theming-module';
+import { updateWorkspace } from '@schematics/angular/utility/workspace';
+import { Change, InsertChange } from '@schematics/angular/utility/change';
+import { Rule } from '@angular-devkit/schematics';
+import { Schema } from '../schema';
+import { addThemingModule } from './add-theming-module';
+import { getProjectDefinition } from "../utils/get-project-definition";
 
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
@@ -11,21 +12,9 @@ export function addTheming(options: Schema): Rule {
         return;
       }
 
-      const currentWorkspace = workspace.projects.get(options.project);
+      const projectDefinition = getProjectDefinition(workspace, options.project);
 
-      if (!currentWorkspace) {
-        throw new SchematicsException('Project with such name not found.');
-      }
-
-      const buildTargetOptions = currentWorkspace.targets.get('build')?.options;
-
-      if (!buildTargetOptions) {
-        throw new SchematicsException(
-          'Could not find build target options for defined project.'
-        );
-      }
-
-      const update: { changes: Change[], file: string } = addThemingModule(tree, currentWorkspace, context, options);
+      const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);
       const exportRecorder = tree.beginUpdate(update.file);
 
       for (const change of update.changes) {

--- a/libs/angular-generator/src/lib/schematics/common-schematics/utils/get-project-definition.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/utils/get-project-definition.ts
@@ -1,0 +1,11 @@
+import { ProjectDefinition, WorkspaceDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectDefinition(workspace: WorkspaceDefinition, projectName: string): ProjectDefinition {
+  const projectDefinition = workspace.projects.get(projectName);
+
+  if (!projectDefinition) {
+    throw new SchematicsException('Project with such name not found.');
+  }
+  return projectDefinition;
+}

--- a/libs/angular-generator/src/lib/schematics/common-schematics/utils/get-project-target.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/utils/get-project-target.ts
@@ -1,0 +1,10 @@
+import { ProjectDefinition, TargetDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectTarget(projectDefinition: ProjectDefinition, targetName: string, projectName?: string): TargetDefinition {
+  const target = projectDefinition.targets.get(targetName)
+  if (!target) {
+    throw new SchematicsException(`Target ${targetName} not found in project ${projectName || ''}`);
+  }
+  return target;
+}

--- a/libs/fundamental-styles/schematics/add-theming/index.ts
+++ b/libs/fundamental-styles/schematics/add-theming/index.ts
@@ -1,8 +1,9 @@
-import {updateWorkspace} from '@schematics/angular/utility/workspace';
-import {Change, InsertChange} from '@schematics/angular/utility/change';
-import {Rule, SchematicsException} from '@angular-devkit/schematics';
-import {Schema} from '../schema';
-import {addThemingModule} from './add-theming-module';
+import { updateWorkspace } from '@schematics/angular/utility/workspace';
+import { Change, InsertChange } from '@schematics/angular/utility/change';
+import { Rule } from '@angular-devkit/schematics';
+import { Schema } from '../schema';
+import { addThemingModule } from './add-theming-module';
+import { getProjectDefinition } from "../utils/get-project-definition";
 
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
@@ -11,21 +12,9 @@ export function addTheming(options: Schema): Rule {
         return;
       }
 
-      const currentWorkspace = workspace.projects.get(options.project);
+      const projectDefinition = getProjectDefinition(workspace, options.project);
 
-      if (!currentWorkspace) {
-        throw new SchematicsException('Project with such name not found.');
-      }
-
-      const buildTargetOptions = currentWorkspace.targets.get('build')?.options;
-
-      if (!buildTargetOptions) {
-        throw new SchematicsException(
-          'Could not find build target options for defined project.'
-        );
-      }
-
-      const update: { changes: Change[], file: string } = addThemingModule(tree, currentWorkspace, context, options);
+      const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);
       const exportRecorder = tree.beginUpdate(update.file);
 
       for (const change of update.changes) {

--- a/libs/fundamental-styles/schematics/utils/get-project-definition.ts
+++ b/libs/fundamental-styles/schematics/utils/get-project-definition.ts
@@ -1,0 +1,11 @@
+import { ProjectDefinition, WorkspaceDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectDefinition(workspace: WorkspaceDefinition, projectName: string): ProjectDefinition {
+  const projectDefinition = workspace.projects.get(projectName);
+
+  if (!projectDefinition) {
+    throw new SchematicsException('Project with such name not found.');
+  }
+  return projectDefinition;
+}

--- a/libs/fundamental-styles/schematics/utils/get-project-target.ts
+++ b/libs/fundamental-styles/schematics/utils/get-project-target.ts
@@ -1,0 +1,10 @@
+import { ProjectDefinition, TargetDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectTarget(projectDefinition: ProjectDefinition, targetName: string, projectName?: string): TargetDefinition {
+  const target = projectDefinition.targets.get(targetName)
+  if (!target) {
+    throw new SchematicsException(`Target ${targetName} not found in project ${projectName || ''}`);
+  }
+  return target;
+}

--- a/libs/ui5-angular/i18n/i18n.module.ts
+++ b/libs/ui5-angular/i18n/i18n.module.ts
@@ -1,16 +1,12 @@
-import {Inject, ModuleWithProviders, NgModule} from "@angular/core";
-import {setFetchDefaultLanguage, setLanguage} from "@ui5/webcomponents-base/dist/config/Language.js";
-import {I18nPipe} from "./i18n.pipe";
-import {I18nService} from "./i18n.service";
-import {I18nConfig} from "./i18n.types";
-import {I18N_NAMESPACE, I18N_ROOT_CONFIG} from "./i18n.tokens";
-import {resolveTranslationsProvider} from "./i18n.utils";
+import { Inject, ModuleWithProviders, NgModule } from "@angular/core";
+import { I18nPipe } from "./i18n.pipe";
+import { I18nConfig } from "./i18n.types";
+import { I18N_ROOT_CONFIG } from "./i18n.tokens";
+import { i18nChildProviders, i18nRootProviders } from "./i18n.providers";
 
-
-let childIds = 0;
 
 @NgModule({
-  declarations: [I18nPipe],
+  imports: [I18nPipe],
   exports: [I18nPipe]
 })
 export class Ui5I18nModule {
@@ -23,24 +19,7 @@ export class Ui5I18nModule {
     return {
       ngModule: Ui5I18nModule,
       providers: [
-        {
-          provide: I18N_ROOT_CONFIG,
-          useFactory: () => {
-            if (config.language) {
-              setLanguage(config.language);
-            }
-            if (config.fetchDefaultLanguage) {
-              setFetchDefaultLanguage(config.fetchDefaultLanguage);
-            }
-            return config;
-          }
-        },
-        {
-          provide: I18N_NAMESPACE,
-          useValue: config.bundle?.name || 'root_i18n'
-        },
-        resolveTranslationsProvider(config.bundle?.translations),
-        I18nService
+        i18nRootProviders(config)
       ]
     }
   }
@@ -49,12 +28,7 @@ export class Ui5I18nModule {
     return {
       ngModule: Ui5I18nModule,
       providers: [
-        {
-          provide: I18N_NAMESPACE,
-          useValue: config?.name || ++childIds + '_i18n'
-        },
-        resolveTranslationsProvider(config?.translations),
-        I18nService
+        i18nChildProviders(config)
       ]
     }
   }

--- a/libs/ui5-angular/i18n/i18n.pipe.ts
+++ b/libs/ui5-angular/i18n/i18n.pipe.ts
@@ -4,7 +4,8 @@ import {distinctUntilChanged, Subject, Subscription, takeUntil} from "rxjs";
 
 @Pipe({
   name: 'ui5I18n',
-  pure: false
+  pure: false,
+  standalone: true
 })
 export class I18nPipe implements PipeTransform, OnDestroy {
   private _lastTranslationValue = '';

--- a/libs/ui5-angular/i18n/i18n.providers.ts
+++ b/libs/ui5-angular/i18n/i18n.providers.ts
@@ -1,0 +1,40 @@
+import { setFetchDefaultLanguage, setLanguage } from "@ui5/webcomponents-base/dist/config/Language.js";
+import { I18nConfig } from "./i18n.types";
+import { I18N_NAMESPACE, I18N_ROOT_CONFIG } from "./i18n.tokens";
+import { resolveTranslationsProvider } from "./i18n.utils";
+import { I18nService } from "./i18n.service";
+
+let childIds = 0;
+export function i18nRootProviders(config: I18nConfig) {
+  return [
+    {
+      provide: I18N_ROOT_CONFIG,
+      useFactory: () => {
+        if (config.language) {
+          setLanguage(config.language);
+        }
+        if (config.fetchDefaultLanguage) {
+          setFetchDefaultLanguage(config.fetchDefaultLanguage);
+        }
+        return config;
+      }
+    },
+    {
+      provide: I18N_NAMESPACE,
+      useValue: config.bundle?.name || 'root_i18n'
+    },
+    resolveTranslationsProvider(config.bundle?.translations),
+    I18nService
+  ]
+}
+
+export function i18nChildProviders(config: I18nConfig['bundle']) {
+  return [
+    {
+      provide: I18N_NAMESPACE,
+      useValue: config?.name || ++childIds + '_i18n'
+    },
+    resolveTranslationsProvider(config?.translations),
+    I18nService
+  ]
+}

--- a/libs/ui5-angular/i18n/index.ts
+++ b/libs/ui5-angular/i18n/index.ts
@@ -1,3 +1,4 @@
 export * from './i18n.module';
 export * from './i18n.service';
 export * from './i18n.pipe';
+export * from './i18n.providers';

--- a/libs/ui5-angular/schematics/add-i18n/index.ts
+++ b/libs/ui5-angular/schematics/add-i18n/index.ts
@@ -1,0 +1,179 @@
+import { Rule, SchematicsException, Tree } from "@angular-devkit/schematics";
+import * as ts from "typescript";
+import { updateWorkspace } from "@schematics/angular/utility/workspace";
+import { Change, InsertChange } from "@schematics/angular/utility/change";
+import { ProjectDefinition } from "@schematics/angular/utility";
+import { SchematicContext } from "@angular-devkit/schematics/src/engine/interface";
+import { getAppModulePath } from "@schematics/angular/utility/ng-ast-utils";
+import { addImportToModule, insertImport } from "@schematics/angular/utility/ast-utils";
+import { findBootstrapApplicationCall } from "@schematics/angular/private/standalone";
+import { getProjectDefinition } from "../utils/get-project-definition";
+import { getProjectMainFile } from "../utils/project-main-file";
+import { getModuleDeclaration } from "../utils/getModuleDeclaration";
+import { getSourceFile } from "../utils/getSourceFile";
+import { findProvidersLiteral } from "../utils/find-providers-literal";
+
+interface I18nOptions {
+  useI18n: boolean,
+  project: string,
+  defaultLanguage: string,
+}
+
+export function addI18n(options: I18nOptions): Rule {
+  return async (tree: Tree, context: SchematicContext) => updateWorkspace(async (workspace) => {
+    if (!options.useI18n) {
+      return;
+    }
+    const projectDefinition = getProjectDefinition(workspace, options.project);
+    const update: { changes: Change[], file: string } = addI18nModule(tree, projectDefinition, context, options);
+    const exportRecorder = tree.beginUpdate(update.file);
+
+    for (const change of update.changes) {
+      if (change instanceof InsertChange) {
+        exportRecorder.insertLeft(change.pos, change.toAdd);
+      }
+    }
+
+    tree.commitUpdate(exportRecorder);
+  });
+}
+
+function addI18nModule(tree: Tree, projectDefinition: ProjectDefinition, context: SchematicContext, options: I18nOptions): {
+  changes: Change[];
+  file: string
+} {
+  try {
+    return addModuleToNonStandaloneApp(tree, projectDefinition, context, options);
+  } catch (e) {
+    if ((e as { message?: string }).message?.includes('Bootstrap call not found')) {
+      return addModuleToStandaloneApp(tree, projectDefinition, context, options);
+    } else {
+      throw e;
+    }
+  }
+}
+
+function rootProviderConfig(options: I18nOptions) {
+  return `{
+      language: ${JSON.stringify(options.defaultLanguage)},
+      fetchDefaultLanguage: true,
+      bundle: {
+        name: 'app-root-i18n-bundle',
+        translations: {
+            // You can add your translations here. For more information please refer to the documentation.
+            [${JSON.stringify(options.defaultLanguage)}]: {
+                'app-root-title': 'Hello World!'
+            }
+        }
+      }
+    }`
+}
+
+function addModuleToNonStandaloneApp(tree: Tree, projectDefinition: ProjectDefinition, context: SchematicContext, options: I18nOptions): {
+  changes: Change[];
+  file: string
+} {
+  const appModulePath = getAppModulePath(
+    tree,
+    getProjectMainFile(projectDefinition)
+  );
+
+  if (!appModulePath) {
+    throw new SchematicsException(
+      'Could not find root module for defined project.'
+    );
+  }
+  const appModuleSource = getSourceFile(tree, appModulePath);
+
+  const i18nModule = getModuleDeclaration(
+    appModuleSource,
+    'Ui5I18nModule'
+  );
+  const moduleConfig = `\nUi5I18nModule.forRoot(${rootProviderConfig(options)})`;
+  if (i18nModule) {
+    i18nModule.getChildren(appModuleSource);
+    const i18nModuleDecl = i18nModule.getFullText();
+    const appModuleContent = tree.readText(appModulePath).split(i18nModuleDecl).join(moduleConfig);
+    tree.overwrite(appModulePath, appModuleContent);
+    context.logger.info('Found previous Ui5I18nModule. Replaced with new one.');
+    return {changes: [], file: appModulePath};
+  }
+
+  const changes: Change[] = [
+    ...addImportToModule(
+      appModuleSource,
+      appModulePath,
+      moduleConfig,
+      null as unknown as string, // This is because of a bug in the angular schematics
+    ),
+    insertImport(appModuleSource, appModulePath, 'Ui5I18nModule', '@ui5/webcomponents-ngx/i18n')
+  ];
+
+  return {changes, file: appModulePath};
+}
+
+function addModuleToStandaloneApp(tree: Tree, projectDefinition: ProjectDefinition, context: SchematicContext, options: I18nOptions): {
+  changes: Change[];
+  file: string
+} {
+  const mainFile = getProjectMainFile(projectDefinition);
+  const mainFileSource = getSourceFile(tree, mainFile);
+  const bootstrapCall = findBootstrapApplicationCall(mainFileSource);
+  if (!bootstrapCall) {
+    throw new SchematicsException('Could not find bootstrap call in main.ts');
+  }
+  const providersLiteral = findProvidersLiteral(bootstrapCall);
+  const recorder = tree.beginUpdate(mainFile.toString());
+  const printer = ts.createPrinter();
+  const newProviderCall = ts.factory.createCallExpression(ts.factory.createIdentifier('i18nRootProviders'), undefined, [ts.factory.createObjectLiteralExpression([
+    ts.factory.createPropertyAssignment('language', ts.factory.createStringLiteral(options.defaultLanguage)),
+    ts.factory.createPropertyAssignment('fetchDefaultLanguage', ts.factory.createTrue()),
+    ts.factory.createPropertyAssignment('bundle', ts.factory.createObjectLiteralExpression([
+      ts.factory.createPropertyAssignment('name', ts.factory.createStringLiteral('app-root-i18n-bundle')),
+      ts.factory.createPropertyAssignment('translations', ts.factory.createObjectLiteralExpression([
+        ts.factory.createPropertyAssignment(ts.factory.createStringLiteral(options.defaultLanguage), ts.factory.createObjectLiteralExpression([
+          ts.factory.createPropertyAssignment(ts.factory.createStringLiteral('app-root-title'), ts.factory.createStringLiteral('Hello World!')),
+        ])),
+      ])),
+    ])),
+  ], true)]);
+  if (!providersLiteral) {
+    const bootstrapCallParams = [...bootstrapCall.arguments];
+    bootstrapCallParams[1] = ts.factory.createObjectLiteralExpression([createProvidersAssignment([newProviderCall])], true)
+    const newCall = ts.factory.updateCallExpression(
+      bootstrapCall,
+      bootstrapCall.expression,
+      bootstrapCall.typeArguments,
+      bootstrapCallParams,
+    );
+    recorder.remove(bootstrapCall.getStart(), bootstrapCall.getWidth());
+    recorder.insertRight(
+      bootstrapCall.getStart(),
+      printer.printNode(ts.EmitHint.Unspecified, newCall, mainFileSource),
+    );
+  } else {
+    const existingUsageIndex = providersLiteral.elements.findIndex(el => ts.isCallExpression(el) && ts.isIdentifier(el.expression) && el.expression.escapedText === 'i18nRootProviders');
+    const newProvidersLiteral = ts.factory.createArrayLiteralExpression(providersLiteral.elements.filter((_el, i) => i !== existingUsageIndex).concat(newProviderCall))
+    if (existingUsageIndex !== -1) {
+      context.logger.info('Found previous i18nRootProviders call. Replaced with new one.');
+    }
+    recorder.remove(providersLiteral.getStart(), providersLiteral.getWidth());
+    recorder.insertRight(
+      providersLiteral.getStart(),
+      printer.printNode(ts.EmitHint.Unspecified, newProvidersLiteral, mainFileSource),
+    );
+  }
+  const importChange = insertImport(mainFileSource, mainFile, 'i18nRootProviders', '@ui5/webcomponents-ngx/i18n');
+  if (importChange instanceof InsertChange) {
+    recorder.insertLeft(importChange.pos, importChange.toAdd);
+  }
+  tree.commitUpdate(recorder);
+  return {changes: [], file: mainFile};
+}
+
+function createProvidersAssignment(elements: ts.Expression[] = []): ts.PropertyAssignment {
+  return ts.factory.createPropertyAssignment(
+    'providers',
+    ts.factory.createArrayLiteralExpression(elements),
+  );
+}

--- a/libs/ui5-angular/schematics/add-i18n/schema.json
+++ b/libs/ui5-angular/schematics/add-i18n/schema.json
@@ -1,0 +1,26 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "I18nAdd",
+  "title": "",
+  "type": "object",
+  "properties": {
+    "project": {
+      "type": "string",
+      "description": "The name of the project.",
+      "$default": {
+        "$source": "projectName"
+      }
+    },
+    "useI18n": {
+      "type": "boolean",
+      "description": "Whether to use internationalization.",
+      "default": true
+    },
+    "defaultLanguage": {
+      "type": "string",
+      "description": "The default language to use.",
+      "default": "en"
+    }
+  },
+  "required": []
+}

--- a/libs/ui5-angular/schematics/add-theming/index.ts
+++ b/libs/ui5-angular/schematics/add-theming/index.ts
@@ -1,8 +1,9 @@
-import {updateWorkspace} from '@schematics/angular/utility/workspace';
-import {Change, InsertChange} from '@schematics/angular/utility/change';
-import {Rule, SchematicsException} from '@angular-devkit/schematics';
-import {Schema} from '../schema';
-import {addThemingModule} from './add-theming-module';
+import { updateWorkspace } from '@schematics/angular/utility/workspace';
+import { Change, InsertChange } from '@schematics/angular/utility/change';
+import { Rule } from '@angular-devkit/schematics';
+import { Schema } from '../schema';
+import { addThemingModule } from './add-theming-module';
+import { getProjectDefinition } from "../utils/get-project-definition";
 
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
@@ -11,21 +12,9 @@ export function addTheming(options: Schema): Rule {
         return;
       }
 
-      const currentWorkspace = workspace.projects.get(options.project);
+      const projectDefinition = getProjectDefinition(workspace, options.project);
 
-      if (!currentWorkspace) {
-        throw new SchematicsException('Project with such name not found.');
-      }
-
-      const buildTargetOptions = currentWorkspace.targets.get('build')?.options;
-
-      if (!buildTargetOptions) {
-        throw new SchematicsException(
-          'Could not find build target options for defined project.'
-        );
-      }
-
-      const update: { changes: Change[], file: string } = addThemingModule(tree, currentWorkspace, context, options);
+      const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);
       const exportRecorder = tree.beginUpdate(update.file);
 
       for (const change of update.changes) {

--- a/libs/ui5-angular/schematics/collection.json
+++ b/libs/ui5-angular/schematics/collection.json
@@ -29,6 +29,11 @@
       "factory": "./add-theming/index#addTheming",
       "schema": "./add-theming/schema.json",
       "private": true
+    },
+    "add-i18n": {
+      "description": "Adds i18n capabilities to the angular application.",
+      "factory": "./add-i18n/index#addI18n",
+      "schema": "./add-i18n/schema.json"
     }
   }
 }

--- a/libs/ui5-angular/schematics/get-i18n-config.ts
+++ b/libs/ui5-angular/schematics/get-i18n-config.ts
@@ -1,0 +1,20 @@
+import { askQuestion } from './utils/promt';
+
+export async function getI18nConfig() {
+  const useI18n = await askQuestion({
+    type: 'confirm',
+    message:
+      'Would you like to add i18n capabilities into your application?',
+    default: false,
+  }) as unknown as boolean;
+  const defaultLanguage = (useI18n ? await askQuestion({
+    type: 'input',
+    message:
+      'What is the default language of your application?',
+    default: 'en',
+  }) as string : undefined);
+  return {
+    useI18n,
+    defaultLanguage
+  };
+}

--- a/libs/ui5-angular/schematics/ng-add/index.ts
+++ b/libs/ui5-angular/schematics/ng-add/index.ts
@@ -7,12 +7,14 @@ import {
 } from '@angular-devkit/schematics';
 import { RunSchematicTask } from '@angular-devkit/schematics/tasks';
 import { collectConfig } from '../get-config';
-import { Schema } from '../schema';
+import { getI18nConfig } from '../get-i18n-config'
+import { NgAddSchema } from './schema';
 
-export function ngAdd(options: Schema): Rule {
+export function ngAdd(options: NgAddSchema): Rule {
   return async (_: Tree, context: SchematicContext) => {
     const userConfig = await collectConfig();
-    options = { ...options, ...userConfig };
+    const i18nConfig = await getI18nConfig();
+    options = {...options, ...userConfig, ...i18nConfig};
 
     // First, queue dependency installation task.
     const dependenciesTaskId = context.addTask(new RunSchematicTask('add-dependencies', options));
@@ -24,9 +26,10 @@ export function ngAdd(options: Schema): Rule {
   };
 }
 
-export function proceedWithSchematics(options: Schema): Rule {
+export function proceedWithSchematics(options: NgAddSchema): Rule {
   return chain([
-      schematic('add-styles', options),
-      schematic('add-theming', options)
+    schematic('add-styles', options),
+    schematic('add-theming', options),
+    schematic('add-i18n', options),
   ]);
 }

--- a/libs/ui5-angular/schematics/ng-add/schema.ts
+++ b/libs/ui5-angular/schematics/ng-add/schema.ts
@@ -1,0 +1,6 @@
+import { Schema } from '../schema';
+
+export interface NgAddSchema extends Schema {
+  useI18n: boolean;
+  defaultLanguage?: string;
+}

--- a/libs/ui5-angular/schematics/utils/get-project-definition.ts
+++ b/libs/ui5-angular/schematics/utils/get-project-definition.ts
@@ -1,0 +1,11 @@
+import { ProjectDefinition, WorkspaceDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectDefinition(workspace: WorkspaceDefinition, projectName: string): ProjectDefinition {
+  const projectDefinition = workspace.projects.get(projectName);
+
+  if (!projectDefinition) {
+    throw new SchematicsException('Project with such name not found.');
+  }
+  return projectDefinition;
+}

--- a/libs/ui5-angular/schematics/utils/get-project-target.ts
+++ b/libs/ui5-angular/schematics/utils/get-project-target.ts
@@ -1,0 +1,10 @@
+import { ProjectDefinition, TargetDefinition } from "@schematics/angular/utility";
+import { SchematicsException } from "@angular-devkit/schematics";
+
+export function getProjectTarget(projectDefinition: ProjectDefinition, targetName: string, projectName?: string): TargetDefinition {
+  const target = projectDefinition.targets.get(targetName)
+  if (!target) {
+    throw new SchematicsException(`Target ${targetName} not found in project ${projectName || ''}`);
+  }
+  return target;
+}


### PR DESCRIPTION
## Related Issue(s)

closes #41

## Description

- Made i18n pipe standalone and made minor refactorings to have proper standalone functions.
- Added ng-add prompt for adding i18n module. Supports both standalone and ngModule setup projects.
- The schematic is also usable without ng-add, e.g `ng g @ui5/webcomponents-ngx:add-i18n --default-language=ka`. Will add documentation for that once we have more than one user usable schematic.
