### PR TITLE
feat: enable setting bollean attrs to ui5webc ngx wrappers

### DIFF
--- a/apps/documentation/src/app/stories/compat/table.stories.ts
+++ b/apps/documentation/src/app/stories/compat/table.stories.ts
@@ -47,11 +47,11 @@ export const Table: Story<TableComponent> = (
 					<span>Product</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" demand-popin>
 					<span>Supplier</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="800" popin-text="Weight" [demandPopin]="true" class="table-header-text-alignment">
+				<ui5-table-column slot="columns" min-width="800" popin-text="Country" demand-popin class="table-header-text-alignment">
 					<span>Country</span>
 				</ui5-table-column>
 
@@ -103,11 +103,11 @@ export const tableInSingleSelectMode: Story<TableComponent> = (
 					<span>Product</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" demand-popin>
 					<span>Supplier</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="800" popin-text="Weight" [demandPopin]="true" class="table-header-text-alignment">
+				<ui5-table-column slot="columns" min-width="800" popin-text="Country" demand-popin class="table-header-text-alignment">
 					<span>Country</span>
 				</ui5-table-column>
 
@@ -123,7 +123,7 @@ export const tableInSingleSelectMode: Story<TableComponent> = (
 					<ui5-table-cell><span>1 eur / kg</span></ui5-table-cell>
 				</ui5-table-row>
 
-				<ui5-table-row [selected]="true">
+				<ui5-table-row selected>
 					<ui5-table-cell><span>Banana</span></ui5-table-cell>
 					<ui5-table-cell><span>Yellow Company Inc.</span></ui5-table-cell>
 					<ui5-table-cell><span>Ecuador</span></ui5-table-cell>
@@ -159,11 +159,11 @@ export const tableInMultiSelectMode: Story<TableComponent> = (
 					<span>Product</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="600" popin-text="Supplier" demand-popin>
 					<span>Supplier</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="800" popin-text="Weight" [demandPopin]="true" class="table-header-text-alignment">
+				<ui5-table-column slot="columns" min-width="800" popin-text="Country" demand-popin class="table-header-text-alignment">
 					<span>Country</span>
 				</ui5-table-column>
 
@@ -179,14 +179,14 @@ export const tableInMultiSelectMode: Story<TableComponent> = (
 					<ui5-table-cell><span>1 eur / kg</span></ui5-table-cell>
 				</ui5-table-row>
 
-				<ui5-table-row [selected]="true">
+				<ui5-table-row selected>
 					<ui5-table-cell><span>Banana</span></ui5-table-cell>
 					<ui5-table-cell><span>Yellow Company Inc.</span></ui5-table-cell>
 					<ui5-table-cell><span>Ecuador</span></ui5-table-cell>
 					<ui5-table-cell><span>2 eur / kg</span></ui5-table-cell>
 				</ui5-table-row>
 
-				<ui5-table-row [selected]="true">
+				<ui5-table-row selected>
 					<ui5-table-cell><span>Tomato</span></ui5-table-cell>
 					<ui5-table-cell><span>Red Gardens Inc.</span></ui5-table-cell>
 					<ui5-table-cell><span>Bulgaria</span></ui5-table-cell>
@@ -220,11 +220,11 @@ export const tableWithNoData: Story<TableComponent> = (
 					<span style="line-height: 1.4rem">Supplier</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="600" popin-text="Dimensions" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="600" popin-text="Dimensions" demand-popin>
 					<span style="line-height: 1.4rem">Dimensions</span>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="600" popin-text="Weight" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="600" popin-text="Weight" demand-popin>
 					<span style="line-height: 1.4rem">Weight</span>
 				</ui5-table-column>
 
@@ -245,7 +245,7 @@ export const tableWithGroupingAndSingleSelect: Story<
 			<ui5-table-column id="column-1" slot="columns">
 				<ui5-label>City</ui5-label>
 			</ui5-table-column>
-			<ui5-table-column id="column-2" slot="columns" min-width="500" popin-text="Supplier" [demandPopin]="true">
+			<ui5-table-column id="column-2" slot="columns" min-width="500" popin-text="Supplier" demand-popin>
 				<ui5-label>Supplier</ui5-label>
 			</ui5-table-column>
 			<ui5-table-column id="column-3" slot="columns" min-width="500">
@@ -259,7 +259,7 @@ export const tableWithGroupingAndSingleSelect: Story<
 				<ui5-table-cell><span>Company 1</span></ui5-table-cell>
 				<ui5-table-cell><span>Bulgaria</span></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row [selected]="true">
+			<ui5-table-row selected>
 				<ui5-table-cell><span>Plovdiv</span></ui5-table-cell>
 				<ui5-table-cell><span>Company 2</span></ui5-table-cell>
 				<ui5-table-cell><span>Bulgaria</span></ui5-table-cell>
@@ -290,7 +290,7 @@ export const tableWithGroupingAndMultiSelect: Story<TableComponent> = (
 			<ui5-table-column id="column-1" slot="columns">
 				<ui5-label>City</ui5-label>
 			</ui5-table-column>
-			<ui5-table-column id="column-2" slot="columns" min-width="500" popin-text="Supplier" [demandPopin]="true">
+			<ui5-table-column id="column-2" slot="columns" min-width="500" popin-text="Supplier" demand-popin>
 				<ui5-label>Supplier</ui5-label>
 			</ui5-table-column>
 			<ui5-table-column id="column-3" slot="columns" min-width="500">
@@ -304,7 +304,7 @@ export const tableWithGroupingAndMultiSelect: Story<TableComponent> = (
 				<ui5-table-cell><span>Company 1</span></ui5-table-cell>
 				<ui5-table-cell><span>Bulgaria</span></ui5-table-cell>
 			</ui5-table-row>
-			<ui5-table-row [selected]="true">
+			<ui5-table-row selected>
 				<ui5-table-cell><span>Plovdiv</span></ui5-table-cell>
 				<ui5-table-cell><span>Company 2</span></ui5-table-cell>
 				<ui5-table-cell><span>Bulgaria</span></ui5-table-cell>

--- a/apps/documentation/src/app/stories/fiori/dynamicsidecontent.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/dynamicsidecontent.stories.ts
@@ -103,7 +103,7 @@ export const dynamicSideContentWithHideMainContentSet: Story<
 
 		<div class="wrapper100">
 			<ui5-page>
-				<ui5-dynamic-side-content [hideMainContent]="true">
+				<ui5-dynamic-side-content hide-main-content>
 					<div>
 						<h1>Main Content</h1>
 						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>
@@ -132,7 +132,7 @@ export const dynamicSideContentWithHideSideContentSet: Story<
 
 		<div class="wrapper100">
 			<ui5-page>
-				<ui5-dynamic-side-content [hideSideContent]="true">
+				<ui5-dynamic-side-content hide-side-content>
 					<div>
 						<h1>Main Content</h1>
 						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>
@@ -161,7 +161,7 @@ export const dynamicSideContentWithEqualSplitSet: Story<
 
 		<div class="wrapper100">
 			<ui5-page>
-				<ui5-dynamic-side-content [equalSplit]="true" >
+				<ui5-dynamic-side-content equal-split>
 					<div>
 						<h1>Main Content</h1>
 						<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nunc ex mi, elementum et ante commodo, semper sollicitudin magna. Sed dapibus ut tortor quis varius. Sed luctus sem at nunc porta vulputate. Suspendisse lobortis arcu est, quis ultrices ipsum fermentum a. Vestibulum a ipsum placerat ligula gravida fringilla at id ex. Etiam pellentesque lorem sed sagittis aliquam. Quisque semper orci risus, vel efficitur dui euismod aliquet. Morbi sapien sapien, rhoncus et rutrum nec, rhoncus id nisl. Cras non tincidunt enim, id eleifend neque.</p>

--- a/apps/documentation/src/app/stories/fiori/mediagallery.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/mediagallery.stories.ts
@@ -39,7 +39,7 @@ export const usage: Story<MediaGalleryComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-media-gallery [showAllThumbnails]="true">
+		<ui5-media-gallery show-all-thumbnails>
 			<ui5-media-gallery-item>
 				<img src="/assets/images/HT-1000.jpg">
 			</ui5-media-gallery-item>
@@ -67,7 +67,7 @@ export const mediaGalleryWithVerticalLayout: Story<MediaGalleryComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-media-gallery [showAllThumbnails]="true" layout="Vertical">
+		<ui5-media-gallery show-all-thumbnails layout="Vertical">
 			<ui5-media-gallery-item>
 				<img src="/assets/images/HT-1000.jpg">
 			</ui5-media-gallery-item>
@@ -95,7 +95,7 @@ export const mediaGalleryWithThumbnailsOnTheRight: Story<
 > = (args: MediaGalleryComponent & any) => ({
   props: args,
   template: `
-		<ui5-media-gallery [showAllThumbnails]="true" layout="Horizontal" menu-horizontal-align="Right">
+		<ui5-media-gallery show-all-thumbnails layout="Horizontal" menu-horizontal-align="Right">
 			<ui5-media-gallery-item>
 				<img src="/assets/images/HT-1000.jpg">
 			</ui5-media-gallery-item>
@@ -152,7 +152,7 @@ export const mediaGalleryWithDisabledContent: Story<MediaGalleryComponent> = (
   props: args,
   template: `
 		<ui5-media-gallery>
-			<ui5-media-gallery-item [disabled]="true">
+			<ui5-media-gallery-item disabled>
 				<img src="/assets/images/HT-1000.jpg">
 			</ui5-media-gallery-item>
 			<ui5-media-gallery-item>
@@ -171,7 +171,7 @@ export const mediaGalleryWithInitiallySelectedItem: Story<
 			<ui5-media-gallery-item>
 				<img src="/assets/images/HT-1000.jpg">
 			</ui5-media-gallery-item>
-			<ui5-media-gallery-item [selected]="true">
+			<ui5-media-gallery-item selected>
 				<img src="/assets/images/HT-1010.jpg">
 			</ui5-media-gallery-item>
 		</ui5-media-gallery>

--- a/apps/documentation/src/app/stories/fiori/notificationlistgroupitem.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/notificationlistgroupitem.stories.ts
@@ -49,7 +49,7 @@ export const basicSample = () => ({
     priority="High"
   >
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
       priority="High"
     >
@@ -69,7 +69,7 @@ export const basicSample = () => ({
     </ui5-li-notification>
 
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
       priority="High"
     >
@@ -98,10 +98,10 @@ export const basicSample = () => ({
   <ui5-li-notification-group
     title-text="Deliveries"
     priority="Medium"
-    [collapsed]="true"
+    collapsed
   >
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
       priority="Medium"
     >
@@ -119,7 +119,7 @@ export const basicSample = () => ({
     </ui5-li-notification>
 
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
       priority="Medium"
     >
@@ -136,14 +136,14 @@ export const basicSample = () => ({
 
   <ui5-li-notification-group
     priority="Low"
-    [collapsed]="true"
+    collapsed
     title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
   >
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New meeting at Building (#35001)"
       priority="Low"
-      [read]="true"
+     read
     >
       And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet,
       consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor,
@@ -155,10 +155,10 @@ export const basicSample = () => ({
     </ui5-li-notification>
 
     <ui5-li-notification
-      [showClose]="true"
+      show-close
       title-text="New meeting at Building (#35001)"
       priority="Low"
-      [read]="true"
+     read
     >
       And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet,
       consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor,
@@ -180,7 +180,7 @@ export const inShellbar = () => ({
 <ui5-shellbar
   primary-title="Corporate Portal"
   logo="/assets/images/sap-logo-svg.svg"
-  [showNotifications]="true"
+  show-notifications
   notifications-count="6"
   (notificationsClick)="popover.open=true;popover.opener = $event.detail.targetRef"
 >
@@ -193,7 +193,7 @@ export const inShellbar = () => ({
       priority="High"
     >
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
         priority="High"
       >
@@ -211,7 +211,7 @@ export const inShellbar = () => ({
       </ui5-li-notification>
 
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
         priority="High"
       >
@@ -237,10 +237,10 @@ export const inShellbar = () => ({
     <ui5-li-notification-group
       title-text="Deliveries"
       priority="Medium"
-      [collapsed]="true"
+      collapsed
     >
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New Delivery (#2900) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
         priority="Medium"
       >
@@ -253,7 +253,7 @@ export const inShellbar = () => ({
       </ui5-li-notification>
 
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New Delivery (#29001) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
         priority="Medium"
       >
@@ -275,14 +275,14 @@ export const inShellbar = () => ({
 
     <ui5-li-notification-group
       priority="High"
-      [collapsed]="true"
+      collapsed
       title-text="Meetings With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc."
     >
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New meeting at Building (#35001)"
         priority="High"
-        [read]="true"
+       read
       >
         And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
         <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>
@@ -292,10 +292,10 @@ export const inShellbar = () => ({
       </ui5-li-notification>
 
       <ui5-li-notification
-        [showClose]="true"
+        show-close
         title-text="New meeting at Building (#35001)"
         priority="High"
-        [read]="true"
+       read
       >
         And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
         <ui5-avatar icon="employee" size="XS" slot="avatar"></ui5-avatar>

--- a/apps/documentation/src/app/stories/fiori/notificationlistitem.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/notificationlistitem.stories.ts
@@ -49,7 +49,7 @@ export const notificationListItemCustomActions: Story<
   props: args,
   template: `
 		<ui5-list id="myList3" class="full-width" header-text="Notifications">
-			<ui5-li-notification [showClose]="true" priority="Low" title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.">
+			<ui5-li-notification show-close priority="Low" title-text="New order (#2525) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.">
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
 					<img src="/assets/images/avatars/woman_avatar_1.png">
@@ -63,7 +63,7 @@ export const notificationListItemCustomActions: Story<
 				</ui5-menu>
 			</ui5-li-notification>
 
-			<ui5-li-notification [showClose]="true" priority="Low" title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.">
+			<ui5-li-notification show-close priority="Low" title-text="New order (#2526) With a very long title - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.">
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
 					<img src="/assets/images/avatars/man_avatar_1.png">
@@ -76,7 +76,7 @@ export const notificationListItemCustomActions: Story<
 				</ui5-menu>
 			</ui5-li-notification>
 
-			<ui5-li-notification [showClose]="true" priority="Low" title-text="New order (#2525) With a short title">
+			<ui5-li-notification show-close priority="Low" title-text="New order (#2525) With a short title">
 				And with a very long description and long labels of the action buttons - Lorem ipsum dolor sit amet, consectetur adipiscing elit. Praesent feugiat, turpis vel scelerisque pharetra, tellus odio vehicula dolor, nec elementum lectus turpis at nunc.
 				<ui5-avatar size="XS" slot="avatar">
 					<img src="/assets/images/avatars/man_avatar_2.png">

--- a/apps/documentation/src/app/stories/fiori/productswitch.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/productswitch.stories.ts
@@ -54,7 +54,7 @@ export const productSwitchInShellbar: Story<ProductSwitchComponent> = (
         primary-title="Corporate Portal"
         secondary-title="home"
         logo="/assets/images/sap-logo-svg.svg"
-        [showProductSwitch]="true"
+        show-product-switch
         (productSwitchClick)="popover.open=true;popover.opener = $event.detail.targetRef"
 >
 </ui5-shellbar>

--- a/apps/documentation/src/app/stories/fiori/shellbar.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/shellbar.stories.ts
@@ -60,7 +60,7 @@ export const shellBarWithSearchAndNotifications: Story<ShellBarComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-shellbar primary-title="Corporate Portal" secondary-title="secondary title" [showNotifications]="true" notifications-count="22">
+		<ui5-shellbar primary-title="Corporate Portal" secondary-title="secondary title" show-notifications notifications-count="22">
 			<ui5-avatar slot="profile">
 				<img src="/assets/images/avatars/woman_avatar_5.png">
 			</ui5-avatar>
@@ -75,7 +75,7 @@ export const shellBarWithProductSwitchAndCoPilot: Story<ShellBarComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-shellbar primary-title="Corporate Portal" secondary-title="secondary title" [showProductSwitch]="true" [showNotifications]="true" notifications-count="22">
+		<ui5-shellbar primary-title="Corporate Portal" secondary-title="secondary title" show-product-switch show-notifications notifications-count="22">
 			<img slot="logo" src="/assets/images/sap-logo-svg.svg">
 
 			<ui5-avatar slot="profile">

--- a/apps/documentation/src/app/stories/fiori/sidenavigation.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/sidenavigation.stories.ts
@@ -45,7 +45,7 @@ export const basicSideNavigation = () => ({
   <ui5-side-navigation>
       <ui5-side-navigation-item text="Home" icon="home"></ui5-side-navigation-item>
 
-      <ui5-side-navigation-group text="Group 1" [expanded]="true">
+      <ui5-side-navigation-group text="Group 1" expanded>
           <ui5-side-navigation-item text="External Link" icon="chain-link" href="https://sap.com" target="_blank"></ui5-side-navigation-item>
           <ui5-side-navigation-item text="People" expanded icon="group">
             <ui5-side-navigation-sub-item text="From My Team"></ui5-side-navigation-sub-item>
@@ -53,7 +53,7 @@ export const basicSideNavigation = () => ({
           </ui5-side-navigation-item>
       </ui5-side-navigation-group>
 
-      <ui5-side-navigation-group text="Group 2" [expanded]="true">
+      <ui5-side-navigation-group text="Group 2" expanded>
           <ui5-side-navigation-item text="Locations" icon="locate-me" selected></ui5-side-navigation-item>
           <ui5-side-navigation-item text="Locations" disabled icon="locate-me"></ui5-side-navigation-item>
           <ui5-side-navigation-item text="Events" icon="calendar">

--- a/apps/documentation/src/app/stories/fiori/timeline.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/timeline.stories.ts
@@ -32,7 +32,7 @@ export const basicTimeline: Story<TimelineComponent> = (
   props: args,
   template: `
 		<ui5-timeline>
-			<ui5-timeline-item id="test-item" title-text="called" subtitle-text="20.02.2017 11:30" icon="phone" name="John Smith" [nameClickable]="true"></ui5-timeline-item>
+			<ui5-timeline-item id="test-item" title-text="called" subtitle-text="20.02.2017 11:30" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
 			<ui5-timeline-item title-text="Weekly Sync - CP Design" subtitle-text="27.07.2017 (11:00 - 12:30)" icon="calendar">
 				<div>MR SOF02 2.43</div>
 			</ui5-timeline-item>
@@ -49,7 +49,7 @@ export const horizontalTimeline: Story<TimelineComponent> = (
   props: args,
   template: `
 		<ui5-timeline layout="Horizontal">
-			<ui5-timeline-item id="test-item" title-text="called" subtitle-text="20.02.2017 11:30" icon="phone" name="John Smith" [nameClickable]="true"></ui5-timeline-item>
+			<ui5-timeline-item id="test-item" title-text="called" subtitle-text="20.02.2017 11:30" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
 			<ui5-timeline-item title-text="Weekly Sync - CP Design" subtitle-text="27.07.2017 (11:00 - 12:30)" icon="calendar">
 				<div>MR SOF02 2.43</div>
 			</ui5-timeline-item>

--- a/apps/documentation/src/app/stories/fiori/viewsettingsdialog.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/viewsettingsdialog.stories.ts
@@ -48,8 +48,8 @@ export const usage: Story<ViewSettingsDialogComponent> = (
   template: `
 		<ui5-button (click)="vsd.element.show()">Open ViewSettingsDialog</ui5-button>
 		<ui5-view-settings-dialog #vsd="ui5ViewSettingsDialog">
-				<ui5-sort-item slot="sortItems" text="Name" [selected]="true"></ui5-sort-item>
-				<ui5-sort-item slot="sortItems" text="Position"></ui5-sort-item>
+				<ui5-sort-item slot="sortItems" text="Name"></ui5-sort-item>
+				<ui5-sort-item slot="sortItems" text="Position" selected></ui5-sort-item>
 				<ui5-sort-item slot="sortItems" text="Company"></ui5-sort-item>
 				<ui5-sort-item slot="sortItems" text="Department"></ui5-sort-item>
 		

--- a/apps/documentation/src/app/stories/fiori/wizard.stories.ts
+++ b/apps/documentation/src/app/stories/fiori/wizard.stories.ts
@@ -63,8 +63,9 @@ export const wizard: Story<WizardComponent> = (
 ) => ({
   props: args,
   template: `
+		<div style="height: 500px">
 		<ui5-wizard id="wiz">
-			<ui5-wizard-step icon="product" title-text="Product type" [selected]="true">
+			<ui5-wizard-step icon="product" title-text="Product type" selected>
 				<div style="display: flex; min-height: 200px; flex-direction: column;">
 					<ui5-title>1. Product Type</ui5-title><br>
 
@@ -75,11 +76,9 @@ export const wizard: Story<WizardComponent> = (
 					<ui5-label wrapping-type="Normal">Sed fermentum, mi et tristique ullamcorper, sapien sapien faucibus sem, quis pretium nibh lorem malesuada diam. Nulla quis arcu aliquet, feugiat massa semper, volutpat diam. Nam vitae ante posuere, molestie neque sit amet, dapibus velit. Maecenas eleifend tempor lorem. Mauris vitae elementum mi, sed eleifend ligula. Nulla tempor vulputate dolor, nec dignissim quam convallis ut. Praesent vitae commodo felis, ut iaculis felis. Fusce quis eleifend sapien, eget facilisis nibh. Suspendisse est velit, scelerisque ut commodo eget, dignissim quis metus. Cras faucibus consequat gravida. Curabitur vitae quam felis. Phasellus ac leo eleifend, commodo tortor et, varius quam. Aliquam erat volutpat.
 					</ui5-label>
 				</div>
-
-				<ui5-button id="toStep2" design="Emphasized">Step 2</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="hint" title-text="Product Information" [disabled]="true">
+			<ui5-wizard-step icon="hint" title-text="Product Information">
 				<div style="display: flex;flex-direction: column">
 					<ui5-title>2. Product Information</ui5-title><br>
 					<ui5-label wrapping-type="Normal">
@@ -100,7 +99,7 @@ export const wizard: Story<WizardComponent> = (
 						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
 							<ui5-label>Manifacturer</ui5-label>
 							<ui5-select>
-								<ui5-option [selected]="true">Apple</ui5-option>
+								<ui5-option selected>Apple</ui5-option>
 								<ui5-option>Samsung</ui5-option>
 								<ui5-option>Huawei</ui5-option>
 							</ui5-select>
@@ -113,10 +112,10 @@ export const wizard: Story<WizardComponent> = (
 					</div>
 				</div>
 
-				<ui5-button id="toStep3" design="Emphasized" [hidden]="true">Step 3</ui5-button>
+				<ui5-button id="toStep3" design="Emphasized" hidden>Step 3</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="action-settings" title-text="Options" [disabled]="true">
+			<ui5-wizard-step icon="action-settings" title-text="Options">
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>3. Options</ui5-title><br>
 
@@ -136,28 +135,26 @@ export const wizard: Story<WizardComponent> = (
 						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
 							<ui5-label>Availability</ui5-label>
 							<ui5-segmented-button id="segButton1">
-								<ui5-toggle-button icon="employee" [pressed]="true">In stock</ui5-toggle-button>
-								<ui5-toggle-button>In depot</ui5-toggle-button>
-								<ui5-toggle-button>Damaged</ui5-toggle-button>
-								<ui5-toggle-button>Out of stock</ui5-toggle-button>
+								<ui5-segmented-button-item icon="employee" selected>In stock</ui5-segmented-button-item>
+								<ui5-segmented-button-item>In depot</ui5-segmented-button-item>
+								<ui5-segmented-button-item>Damaged</ui5-segmented-button-item>
+								<ui5-segmented-button-item>Out of stock</ui5-segmented-button-item>
 							</ui5-segmented-button>
 						</div>
 
 						<div style="display: flex; flex-direction: row; justify-content: flex-end; align-items: center; margin-top: 1rem">
 							<ui5-label>Size</ui5-label>
 							<ui5-segmented-button id="sb">
-								<ui5-toggle-button icon="employee" [pressed]="true">Small</ui5-toggle-button>
-								<ui5-toggle-button>Medium</ui5-toggle-button>
-								<ui5-toggle-button>Large</ui5-toggle-button>
+								<ui5-segmented-button-item icon="employee" selected>Small</ui5-segmented-button-item>
+								<ui5-segmented-button-item>Medium</ui5-segmented-button-item>
+								<ui5-segmented-button-item>Large</ui5-segmented-button-item>
 							</ui5-segmented-button>
 						</div>
 					</div>
 				</div>
-
-				<ui5-button id="toStep4" design="Emphasized" [hidden]="true">Step 4</ui5-button>
 			</ui5-wizard-step>
 
-			<ui5-wizard-step icon="lead" title-text="Pricing" [disabled]="true">
+			<ui5-wizard-step icon="lead" title-text="Pricing">
 				<div style="display: flex; flex-direction: column;">
 					<ui5-title>4. Pricing</ui5-title><br>
 					<ui5-label wrapping-type="Normal">
@@ -180,7 +177,7 @@ export const wizard: Story<WizardComponent> = (
 
 						<div style="display: flex; flex-direction: row; margin-top: 1rem; justify-content: flex-end; align-items: center;">
 							<ui5-label>Vat included</ui5-label>
-							<ui5-switch [checked]="true"></ui5-switch>
+							<ui5-switch checked></ui5-switch>
 						</div>
 					</div>
 				</div>
@@ -188,5 +185,6 @@ export const wizard: Story<WizardComponent> = (
 				<ui5-button id="finalize" design="Emphasized">Finalize</ui5-button>
 			</ui5-wizard-step>
 		</ui5-wizard>
+		</div>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/bar.stories.ts
+++ b/apps/documentation/src/app/stories/main/bar.stories.ts
@@ -2,21 +2,29 @@ import { Meta, Story, moduleMetadata } from '@storybook/angular';
 import { Ui5WebcomponentsModule, BarComponent } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The Bar is a container which is primarily used to hold titles, buttons and input elements and its design and functionality is the basis for page headers and footers. The component consists of three areas to hold its content - startContent slot, default slot and endContent slot. It has the capability to center content, such as a title, while having other components on the left and right side.
+const description = `
+### Overview 
+The Bar is a container which is primarily used to hold titles, buttons and input elements and its design and functionality is the basis for page headers and footers. The component consists of three areas to hold its content - startContent slot, default slot and endContent slot. It has the capability to center content, such as a title, while having other components on the left and right side.
 
-<h3>Usage</h3> With the use of the design property, you can set the style of the Bar to appear designed like a Header, Subheader, Footer and FloatingFooter. <br> <b>Note:</b> Do not place a Bar inside another Bar or inside any bar-like component. Doing so may cause unpredictable behavior.
+### Usage
 
-<h3>Responsive Behavior</h3> The default slot will be centered in the available space between the startContent and the endContent areas, therefore it might not always be centered in the entire bar.
+With the use of the design property, you can set the style of the Bar to appear designed like a Header, Subheader, Footer and FloatingFooter. <br> <b>Note:</b> Do not place a Bar inside another Bar or inside any bar-like component. Doing so may cause unpredictable behavior.
 
-<h3>CSS Shadow Parts</h3>
+### Responsive Behavior
+
+The default slot will be centered in the available space between the startContent and the endContent areas, therefore it might not always be centered in the entire bar.
+
+### CSS Shadow Parts
 
 <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM. <br> The <code>ui5-bar</code> exposes the following CSS Shadow Parts: <ul> <li>bar - Used to style the wrapper of the content of the component</li> </ul>
 
-<h3>Keyboard Handling</h3>
+### Keyboard Handling
 
-<h4>Fast Navigation</h4> This component provides a build in fast navigation group which can be used via <code>F6 / Shift + F6</code> or <code> Ctrl + Alt(Option) + Down / Ctrl + Alt(Option) + Up</code>. In order to use this functionality, you need to import the following module: <code>import "@ui5/webcomponents-base/dist/features/F6Navigation.js"</code> <br><br>
+#### Fast Navigation 
 
-<h3>ES6 Module Import</h3>
+This component provides a build in fast navigation group which can be used via <code>F6 / Shift + F6</code> or <code> Ctrl + Alt(Option) + Down / Ctrl + Alt(Option) + Up</code>. In order to use this functionality, you need to import the following module: <code>import "@ui5/webcomponents-base/dist/features/F6Navigation.js"</code> <br><br>
+
+### ES6 Module Import
 
 <code>import { BarComponent } from "@ui5/webcomponents-ngx/main/bar";</code>`;
 export default {

--- a/apps/documentation/src/app/stories/main/busyindicator.stories.ts
+++ b/apps/documentation/src/app/stories/main/busyindicator.stories.ts
@@ -41,9 +41,9 @@ export const busyIndicatorWithDifferentSize: Story<BusyIndicatorComponent> = (
 ) => ({
   props: args,
   template: `
-			<ui5-busy-indicator [active]="true" size="S"></ui5-busy-indicator>
-			<ui5-busy-indicator [active]="true" size="M"></ui5-busy-indicator>
-			<ui5-busy-indicator [active]="true" size="L"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="S"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="M"></ui5-busy-indicator>
+			<ui5-busy-indicator active size="L"></ui5-busy-indicator>
 		`,
 });
 

--- a/apps/documentation/src/app/stories/main/button.stories.ts
+++ b/apps/documentation/src/app/stories/main/button.stories.ts
@@ -44,7 +44,7 @@ export const basicButton: Story<ButtonComponent> = (
   props: args,
   template: `
 		<ui5-button design="Default">Default</ui5-button>
-		<ui5-button [disabled]="true">Disabled</ui5-button>
+		<ui5-button disabled>Disabled</ui5-button>
 		<ui5-button design="Transparent">Cancel</ui5-button>
 		<ui5-button design="Positive">Approve</ui5-button>
 		<ui5-button design="Negative">Decline</ui5-button>

--- a/apps/documentation/src/app/stories/main/calendar.stories.ts
+++ b/apps/documentation/src/app/stories/main/calendar.stories.ts
@@ -77,7 +77,7 @@ export const calendarWithHiddenWeekNumbers: Story<CalendarComponent> = (
   props: args,
   template: `
 		<div class="datepicker-width">
-			<ui5-calendar [hideWeekNumbers]="true"></ui5-calendar>
+			<ui5-calendar hide-week-numbers></ui5-calendar>
 		</div>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/card.stories.ts
+++ b/apps/documentation/src/app/stories/main/card.stories.ts
@@ -54,7 +54,7 @@ export const cardWithList: Story<CardComponent> = (
 			</div>
 		</ui5-card>
 		<ui5-card class="medium">
-			<ui5-card-header slot="header" title-text="This header is interactive" [interactive]="true" subtitle-text="Click, press Enter or Space" status="3 of 6">
+			<ui5-card-header slot="header" title-text="This header is interactive" interactive subtitle-text="Click, press Enter or Space" status="3 of 6">
 				<ui5-icon name="group" slot="avatar"></ui5-icon>
 			</ui5-card-header>
 
@@ -91,7 +91,7 @@ export const cardWithTable: Story<CardComponent> = (
 					<ui5-label>Net Amount</ui5-label>
 				</ui5-table-column>
 
-				<ui5-table-column slot="columns" min-width="450" popin-text="Status" [demandPopin]="true">
+				<ui5-table-column slot="columns" min-width="450" popin-text="Status" demand-popin>
 					<ui5-label>Status</ui5-label>
 				</ui5-table-column>
 
@@ -153,7 +153,7 @@ export const cardWithTimeline: Story<CardComponent> = (
 			<ui5-card-header slot="header" title-text="Upcoming Activities" subtitle-text="For Today">
 			</ui5-card-header>
 			<ui5-timeline>
-				<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" [nameClickable]="true"></ui5-timeline-item>
+				<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
 				<ui5-timeline-item title-text="Weekly Sync - CP Design" timestamp="1517349600000" icon="calendar">
 					MR SOF02 2.43
 				</ui5-timeline-item>
@@ -174,9 +174,9 @@ export const moreCards: Story<CardComponent> = (args: CardComponent & any) => ({
 			</ui5-card-header>
 
 			<ui5-list separators="Inner">
-				<ui5-li icon="competitor" [iconEnd]="true">Personal Development</ui5-li>
-				<ui5-li icon="wallet" [iconEnd]="true">Finance</ui5-li>
-				<ui5-li icon="collaborate" [iconEnd]="true">Communications Skills</ui5-li>
+				<ui5-li icon="competitor" icon-end>Personal Development</ui5-li>
+				<ui5-li icon="wallet" icon-end>Finance</ui5-li>
+				<ui5-li icon="collaborate" icon-end>Communications Skills</ui5-li>
 			</ui5-list>
 		</ui5-card>
 

--- a/apps/documentation/src/app/stories/main/carousel.stories.ts
+++ b/apps/documentation/src/app/stories/main/carousel.stories.ts
@@ -73,7 +73,7 @@ export const carouselWithMultipleItemsPerPage: Story<CarouselComponent> = (
 				<ui5-card-header slot="header" title-text="Activities" subtitle-text="For Today"></ui5-card-header>
 
 				<ui5-timeline>
-					<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" [nameClickable]="true"></ui5-timeline-item>
+					<ui5-timeline-item id="test-item" title-text="called" timestamp="1487583000000" icon="phone" name="John Smith" name-clickable></ui5-timeline-item>
 					<ui5-timeline-item title-text="Weekly Sync - CP Design" timestamp="1517349600000" icon="calendar">
 						MR SOF02 2.43
 					</ui5-timeline-item>
@@ -89,9 +89,9 @@ export const carouselWithMultipleItemsPerPage: Story<CarouselComponent> = (
 				</ui5-card-header>
 
 				<ui5-list separators="Inner" class="content-padding">
-					<ui5-li icon="competitor" [iconEnd]="true">Personal Development</ui5-li>
-					<ui5-li icon="wallet" [iconEnd]="true">Finance</ui5-li>
-					<ui5-li icon="collaborate" [iconEnd]="true">Communications Skills</ui5-li>
+					<ui5-li icon="competitor" icon-end>Personal Development</ui5-li>
+					<ui5-li icon="wallet" icon-end>Finance</ui5-li>
+					<ui5-li icon="collaborate" icon-end>Communications Skills</ui5-li>
 				</ui5-list>
 			</ui5-card>
 
@@ -110,7 +110,7 @@ export const carouselWithMultipleItemsPerPage: Story<CarouselComponent> = (
 			</ui5-card>
 
 			<ui5-card class="medium">
-				<ui5-card-header slot="header" title-text="Team Bears" subtitle-text="Direct Reports" [interactive]="true" status="2 of 2">
+				<ui5-card-header slot="header" title-text="Team Bears" subtitle-text="Direct Reports" interactive status="2 of 2">
 						<ui5-icon name="group" slot="avatar"></ui5-icon>
 				</ui5-card-header>
 
@@ -131,7 +131,7 @@ export const carouselWithArrowPlacementAndCyclic: Story<CarouselComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-carousel arrows-placement="Navigation" [cyclic]="true">
+		<ui5-carousel arrows-placement="Navigation" cyclic>
 			<img src="../../../assets/images/sample1.jpg" alt="Landscape 1">
 			<img src="../../../assets/images/sample2.jpg" alt="Landscape 2">
 			<img src="../../../assets/images/sample3.jpg" alt="Bulb">

--- a/apps/documentation/src/app/stories/main/checkbox.stories.ts
+++ b/apps/documentation/src/app/stories/main/checkbox.stories.ts
@@ -43,10 +43,10 @@ export const basicCheckBox: Story<CheckBoxComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-checkbox text="Chocolate" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Strawberry" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Waffles" [checked]="true" value-state="Negative"></ui5-checkbox>
-		<ui5-checkbox text="Cake" [checked]="true" value-state="Critical"></ui5-checkbox>
+		<ui5-checkbox text="Chocolate" checked></ui5-checkbox>
+		<ui5-checkbox text="Strawberry" checked></ui5-checkbox>
+		<ui5-checkbox text="Waffles" checked value-state="Negative"></ui5-checkbox>
+		<ui5-checkbox text="Cake" checked value-state="Critical"></ui5-checkbox>
 	`,
 });
 
@@ -59,20 +59,20 @@ export const checkBoxStates: Story<CheckBoxComponent> = (
 		<ui5-checkbox text="Negative" value-state="Negative"></ui5-checkbox>
 		<ui5-checkbox text="Critical" value-state="Critical"></ui5-checkbox>
 		<ui5-checkbox text="Information" value-state="Information"></ui5-checkbox>
-		<ui5-checkbox text="Disabled" [disabled]="true" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Readonly" [readonly]="true" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Success disabled" [disabled]="true" value-state="Positive" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Error disabled" [disabled]="true" value-state="Negative" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Warning disabled " [disabled]="true" value-state="Critical" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Information disabled " [disabled]="true" value-state="Information" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Success readonly" [readonly]="true" value-state="Positive" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Error readonly" [readonly]="true" value-state="Negative" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Warning readonly" [readonly]="true" value-state="Critical" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Information readonly" [readonly]="true" value-state="Information" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Success indeterminate" value-state="Positive" [indeterminate]="true" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Error indeterminate" value-state="Negative" [indeterminate]="true" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Warning indeterminate" value-state="Critical" [indeterminate]="true" [checked]="true"></ui5-checkbox>
-		<ui5-checkbox text="Information indeterminate" value-state="Information" [indeterminate]="true" [checked]="true"></ui5-checkbox>
+		<ui5-checkbox text="Disabled" disabled checked></ui5-checkbox>
+		<ui5-checkbox text="Readonly" readonly checked></ui5-checkbox>
+		<ui5-checkbox text="Success disabled" disabled value-state="Positive" checked></ui5-checkbox>
+		<ui5-checkbox text="Error disabled" disabled value-state="Negative" checked></ui5-checkbox>
+		<ui5-checkbox text="Warning disabled " disabled value-state="Critical" checked></ui5-checkbox>
+		<ui5-checkbox text="Information disabled " disabled value-state="Information" checked></ui5-checkbox>
+		<ui5-checkbox text="Success readonly" readonly value-state="Positive" checked></ui5-checkbox>
+		<ui5-checkbox text="Error readonly" readonly value-state="Negative" checked></ui5-checkbox>
+		<ui5-checkbox text="Warning readonly" readonly value-state="Critical" checked></ui5-checkbox>
+		<ui5-checkbox text="Information readonly" readonly value-state="Information" checked></ui5-checkbox>
+		<ui5-checkbox text="Success indeterminate" value-state="Positive" indeterminate checked></ui5-checkbox>
+		<ui5-checkbox text="Error indeterminate" value-state="Negative" indeterminate checked></ui5-checkbox>
+		<ui5-checkbox text="Warning indeterminate" value-state="Critical" indeterminate checked></ui5-checkbox>
+		<ui5-checkbox text="Information indeterminate" value-state="Information" indeterminate checked></ui5-checkbox>
 	`,
 });
 

--- a/apps/documentation/src/app/stories/main/colorpalettepopover.stories.ts
+++ b/apps/documentation/src/app/stories/main/colorpalettepopover.stories.ts
@@ -43,7 +43,7 @@ export const colorPalettePopoverWithRecentColorsDefaultColorAndMoreColorsFeature
   template: `
 		<ui5-button id="btn" (click)="colorPalettePopover.open=true">Open ColorPalettePopover</ui5-button>
 
-		<ui5-color-palette-popover opener="btn" #colorPalettePopover="ui5ColorPalettePopover" [showRecentColors]="true" [showDefaultColor]="true" default-color="green">
+		<ui5-color-palette-popover opener="btn" #colorPalettePopover="ui5ColorPalettePopover" show-recent-colors show-default-color default-color="green">
 			<ui5-color-palette-item value="pink"></ui5-color-palette-item>
 			<ui5-color-palette-item value="darkblue"></ui5-color-palette-item>
 			<ui5-color-palette-item value="#444444"></ui5-color-palette-item>

--- a/apps/documentation/src/app/stories/main/combobox.stories.ts
+++ b/apps/documentation/src/app/stories/main/combobox.stories.ts
@@ -78,13 +78,13 @@ export const disabledAndReadonlyProperties: Story<ComboBoxComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-combobox value="Disabled" [disabled]="true">
+		<ui5-combobox value="Disabled" disabled>
 			<ui5-cb-item text="Item 1"></ui5-cb-item>
 			<ui5-cb-item text="Item 2"></ui5-cb-item>
 			<ui5-cb-item text="Item 3"></ui5-cb-item>
 		</ui5-combobox>
 
-		<ui5-combobox value="Readonly" [readonly]="true">
+		<ui5-combobox value="Readonly" readonly>
 			<ui5-cb-item text="Item 1"></ui5-cb-item>
 			<ui5-cb-item text="Item 2"></ui5-cb-item>
 			<ui5-cb-item text="Item 3"></ui5-cb-item>

--- a/apps/documentation/src/app/stories/main/datepicker.stories.ts
+++ b/apps/documentation/src/app/stories/main/datepicker.stories.ts
@@ -4,6 +4,10 @@ import {
   DatePickerComponent,
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
+import "@ui5/webcomponents-localization/dist/features/calendar/Buddhist.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Islamic.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Japanese.js";
+import "@ui5/webcomponents-localization/dist/features/calendar/Persian.js";
 
 const description = `### Overview
 
@@ -148,7 +152,7 @@ export const disabledDatePicker: Story<DatePickerComponent> = (
   props: args,
   template: `
 			<div class="datepicker-width">
-				<ui5-date-picker [disabled]="true" value="8 September 2021"></ui5-date-picker>
+				<ui5-date-picker disabled value="8 September 2021"></ui5-date-picker>
 			</div>
 		`,
 });
@@ -159,7 +163,7 @@ export const readonlyDatePicker: Story<DatePickerComponent> = (
   props: args,
   template: `
 			<div class="datepicker-width">
-				<ui5-date-picker [readonly]="true" value="8 September 2021"></ui5-date-picker>
+				<ui5-date-picker readonly value="8 September 2021"></ui5-date-picker>
 			</div>
 		`,
 });

--- a/apps/documentation/src/app/stories/main/daterangepicker.stories.ts
+++ b/apps/documentation/src/app/stories/main/daterangepicker.stories.ts
@@ -71,7 +71,7 @@ export const disabledDateRangePicker: Story<DateRangePickerComponent> = (
   props: args,
   template: `
 		<div class="daterange-picker-width">
-			<ui5-daterange-picker [disabled]="true" value="Mar 31, 2021 - Apr 9, 2021"></ui5-daterange-picker>
+			<ui5-daterange-picker disabled value="Mar 31, 2021 - Apr 9, 2021"></ui5-daterange-picker>
 		</div>
 	`,
 });
@@ -82,7 +82,7 @@ export const readonlyDateRangePicker: Story<DateRangePickerComponent> = (
   props: args,
   template: `
 		<div class="daterange-picker-width">
-			<ui5-daterange-picker [readonly]="true" value="Mar 31, 2021 - Apr 9, 2021"></ui5-daterange-picker>
+			<ui5-daterange-picker readonly value="Mar 31, 2021 - Apr 9, 2021"></ui5-daterange-picker>
 		</div>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/datetimepicker.stories.ts
+++ b/apps/documentation/src/app/stories/main/datetimepicker.stories.ts
@@ -69,7 +69,7 @@ export const dateTimePickerInStates: Story<DateTimePickerComponent> = (
 		<ui5-datetime-picker value-state="Information"></ui5-datetime-picker>
 		<ui5-datetime-picker value-state="Positive"></ui5-datetime-picker>
 		<br><br>
-		<ui5-datetime-picker [readonly]="true" value="2020-04-13-04:16:16 AM"></ui5-datetime-picker>
-		<ui5-datetime-picker [disabled]="true" value="2020-04-13-04:16:16 AM"></ui5-datetime-picker>
+		<ui5-datetime-picker readonly value="2020-04-13-04:16:16 AM"></ui5-datetime-picker>
+		<ui5-datetime-picker disabled value="2020-04-13-04:16:16 AM"></ui5-datetime-picker>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/dialog.stories.ts
+++ b/apps/documentation/src/app/stories/main/dialog.stories.ts
@@ -52,7 +52,7 @@ export const draggableAndResizableDialog: Story<DialogComponent> = (
   template: `
 		<ui5-button (click)="dialog.open=true" >Open Draggable/Resizable dialog</ui5-button>
 
-		<ui5-dialog #dialog="ui5Dialog" header-text="Draggable/Resizable dialog" [resizable]="true" [draggable]="true">
+		<ui5-dialog #dialog="ui5Dialog" header-text="Draggable/Resizable dialog" resizable draggable>
 			<p>Resize this dialog by dragging it by its resize handle.</p>
 			<p>This feature available only on Desktop.</p>
 

--- a/apps/documentation/src/app/stories/main/fileuploader.stories.ts
+++ b/apps/documentation/src/app/stories/main/fileuploader.stories.ts
@@ -46,7 +46,7 @@ export const fileUploaderWithNoInput: Story<FileUploaderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-file-uploader [hideInput]="true">
+		<ui5-file-uploader hide-input>
 			<ui5-button>Upload File</ui5-button>
 		</ui5-file-uploader>
 	`,
@@ -57,11 +57,11 @@ export const customFileUploaders: Story<FileUploaderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-file-uploader [hideInput]="true">
+		<ui5-file-uploader hide-input>
 			<ui5-avatar icon="upload"></ui5-avatar>
 		</ui5-file-uploader>
 
-		<ui5-file-uploader [hideInput]="true">
+		<ui5-file-uploader hide-input>
 			<ui5-tag>Upload File</ui5-tag>
 		</ui5-file-uploader>
 	`,

--- a/apps/documentation/src/app/stories/main/input.stories.ts
+++ b/apps/documentation/src/app/stories/main/input.stories.ts
@@ -36,9 +36,9 @@ export const basicInput: Story<InputComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-input class="samples-margin samples-responsive-margin-bottom" [showClearIcon]="true" value="Input"></ui5-input>
-		<ui5-input class="samples-margin samples-responsive-margin-bottom" [readonly]="true" value="readonly Input"></ui5-input>
-		<ui5-input class="samples-margin samples-responsive-margin-bottom" [disabled]="true" value="Disabled Input"></ui5-input>
+		<ui5-input class="samples-margin samples-responsive-margin-bottom" show-clear-icon value="Input"></ui5-input>
+		<ui5-input class="samples-margin samples-responsive-margin-bottom" readonly value="readonly Input"></ui5-input>
+		<ui5-input class="samples-margin samples-responsive-margin-bottom" disabled value="Disabled Input"></ui5-input>
 	`,
 });
 
@@ -73,12 +73,12 @@ export const inputWithLabel: Story<InputComponent> = (
   props: args,
   template: `
 		<div class="flex-column samples-margin">
-			<ui5-label class="samples-big-margin-right" for="myInput" [required]="true" [showColon]="true">Name</ui5-label>
-			<ui5-input id="myInput" placeholder="Enter your Name" [required]="true"></ui5-input>
+			<ui5-label class="samples-big-margin-right" for="myInput" required showColon>Name</ui5-label>
+			<ui5-input id="myInput" placeholder="Enter your Name" required></ui5-input>
 		</div>
 		<div class="flex-column">
-			<ui5-label class="samples-big-margin-right" for="myPassword" [required]="true" [showColon]="true">Secret Code</ui5-label>
-			<ui5-input id="myPassword" type="Password" value-state="Negative" placeholder="Enter your Secret Code" [required]="true"></ui5-input>
+			<ui5-label class="samples-big-margin-right" for="myPassword" required showColon>Secret Code</ui5-label>
+			<ui5-input id="myPassword" type="Password" value-state="Negative" placeholder="Enter your Secret Code" required></ui5-input>
 		</div>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/label.stories.ts
+++ b/apps/documentation/src/app/stories/main/label.stories.ts
@@ -41,7 +41,7 @@ export const requiredLabel: Story<LabelComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-label [required]="true">Required Label</ui5-label>
+		<ui5-label required>Required Label</ui5-label>
 	`,
 });
 
@@ -50,7 +50,7 @@ export const requiredLabelWithColon: Story<LabelComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-label [required]="true" [showColon]="true">Required Label</ui5-label>
+		<ui5-label required showColon>Required Label</ui5-label>
 	`,
 });
 
@@ -77,25 +77,25 @@ export const labelFor: Story<LabelComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-label id="myLabel" for="myInput" [required]="true" [showColon]="true">First name</ui5-label>
-		<ui5-input id="myInput" [required]="true" placeholder="Enter your name"></ui5-input>
+		<ui5-label id="myLabel" for="myInput" required showColon>First name</ui5-label>
+		<ui5-input id="myInput" required placeholder="Enter your name"></ui5-input>
 		<br>
-		<ui5-label id="myLabel2" for="myDP" [required]="true" [showColon]="true">Date of birth</ui5-label>
-		<ui5-date-picker id="myDP" [required]="true"></ui5-date-picker>
+		<ui5-label id="myLabel2" for="myDP" required showColon>Date of birth</ui5-label>
+		<ui5-date-picker id="myDP" required></ui5-date-picker>
 		<br>
-		<ui5-label id="myLabel3" for="mySelect" [required]="true" [showColon]="true">Job</ui5-label>
-		<ui5-select id="mySelect" [required]="true">
+		<ui5-label id="myLabel3" for="mySelect" required showColon>Job</ui5-label>
+		<ui5-select id="mySelect" required>
 			<ui5-option>Manager</ui5-option>
 			<ui5-option>Sales</ui5-option>
-			<ui5-option [selected]="true">Developer</ui5-option>
+			<ui5-option selected>Developer</ui5-option>
 		</ui5-select>
 		<br>
-		<ui5-label id="myLabel4" for="myTextArea" [required]="true" [showColon]="true">Description label test</ui5-label>
-		<ui5-textarea id="myTextArea" [required]="true" placeholder="Type as much text as you wish"></ui5-textarea>
+		<ui5-label id="myLabel4" for="myTextArea" required showColon>Description label test</ui5-label>
+		<ui5-textarea id="myTextArea" required placeholder="Type as much text as you wish"></ui5-textarea>
 		<br>
 		<div style="display: flex; align-items: center;">
-			<ui5-label for="myCB" [required]="true" [showColon]="true">Accept terms of use</ui5-label>
-			<ui5-checkbox id="myCB" [required]="true"></ui5-checkbox>
+			<ui5-label for="myCB" required showColon>Accept terms of use</ui5-label>
+			<ui5-checkbox id="myCB" required></ui5-checkbox>
 		</div>
 		<pre class="prettyprint lang-html"><xmp>
 <ui5-label id="myLabel" for="myInput" required show-colon>First name</ui5-label>

--- a/apps/documentation/src/app/stories/main/link.stories.ts
+++ b/apps/documentation/src/app/stories/main/link.stories.ts
@@ -40,7 +40,7 @@ export const differentLinkDesigns: Story<LinkComponent> = (
   template: `
 		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank">Standard Link</ui5-link>
 		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" design="Subtle">Subtle link</ui5-link>
-		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" [disabled]="true">Disabled</ui5-link>
+		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" disabled>Disabled</ui5-link>
 		<ui5-link class="samples-big-margin-right" href="https://www.sap.com" target="_blank" design="Emphasized">Emphasized</ui5-link>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/list.stories.ts
+++ b/apps/documentation/src/app/stories/main/list.stories.ts
@@ -74,7 +74,7 @@ export const listInMultiSelectionMode: Story<ListComponent> = (
   template: `
 		<ui5-list id="myList1" class="samples-margin-bottom full-width" mode="MultiSelect" header-text="Multiple selection is possible">
 				<ui5-li>Pineapple</ui5-li>
-				<ui5-li [selected]="true">Orange</ui5-li>
+				<ui5-li selected>Orange</ui5-li>
 				<ui5-li>Banana</ui5-li>
 				<ui5-li>Mango</ui5-li>
 		</ui5-list>
@@ -84,7 +84,7 @@ export const listInMultiSelectionMode: Story<ListComponent> = (
 export const busyList: Story<ListComponent> = (args: ListComponent & any) => ({
   props: args,
   template: `
-		<ui5-list header-text="Fetching data ..." class="full-width" [loading]="true"></ui5-list>
+		<ui5-list header-text="Fetching data ..." class="full-width" loading></ui5-list>
 	`,
 });
 
@@ -95,21 +95,21 @@ export const listWithGroupHeaders: Story<ListComponent> = (
   template: `
 		<ui5-list header-text="Community" mode="MultiSelect">
 			<ui5-li-group header-text="Front End Developers">
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" [iconEnd]="true">Jennifer</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_4.png" icon="navigation-right-arrow" [iconEnd]="true">Lora</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_5.png" icon="navigation-right-arrow" [iconEnd]="true">Carlotta</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Jennifer</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_4.png" icon="navigation-right-arrow" icon-end>Lora</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_5.png" icon="navigation-right-arrow" icon-end>Carlotta</ui5-li>
 			</ui5-li-group>
 
 			<ui5-li-group header-text="Back End Developers">
-				<ui5-li image="../../../assets/images/avatars/man_avatar_1.png" icon="navigation-right-arrow" [iconEnd]="true">Clark</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" icon="navigation-right-arrow" [iconEnd]="true">Ellen</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" icon="navigation-right-arrow" [iconEnd]="true">Adam</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/man_avatar_1.png" icon="navigation-right-arrow" icon-end>Clark</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_1.png" icon="navigation-right-arrow" icon-end>Ellen</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/man_avatar_2.png" icon="navigation-right-arrow" icon-end>Adam</ui5-li>
 			</ui5-li-group>
 
 			<ui5-li-group header-text="Full-stack Developers">
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" icon="navigation-right-arrow" [iconEnd]="true">Susan</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" icon="navigation-right-arrow" [iconEnd]="true">David</ui5-li>
-				<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" [iconEnd]="true">Natalie</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_2.png" icon="navigation-right-arrow" icon-end>Susan</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/man_avatar_3.png" icon="navigation-right-arrow" icon-end>David</ui5-li>
+				<ui5-li image="../../../assets/images/avatars/woman_avatar_3.png" icon="navigation-right-arrow" icon-end>Natalie</ui5-li>
 			</ui5-li-group>
 		</ui5-list>
 	`,

--- a/apps/documentation/src/app/stories/main/messagestrip.stories.ts
+++ b/apps/documentation/src/app/stories/main/messagestrip.stories.ts
@@ -55,10 +55,10 @@ export const messageStripWithNoCloseButton: Story<MessageStripComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-message-strip design="Information" [hideCloseButton]="true">Information MessageStrip With No Close Button</ui5-message-strip>
-		<ui5-message-strip design="Positive" [hideCloseButton]="true">Positive MessageStrip With No Close Button</ui5-message-strip>
-		<ui5-message-strip design="Negative" [hideCloseButton]="true">Negative MessageStrip With No Close Button</ui5-message-strip>
-		<ui5-message-strip design="Critical" [hideCloseButton]="true">Warning MessageStrip With No Close Button</ui5-message-strip>
+		<ui5-message-strip design="Information" hide-close-button>Information MessageStrip With No Close Button</ui5-message-strip>
+		<ui5-message-strip design="Positive" hide-close-button>Positive MessageStrip With No Close Button</ui5-message-strip>
+		<ui5-message-strip design="Negative" hide-close-button>Negative MessageStrip With No Close Button</ui5-message-strip>
+		<ui5-message-strip design="Critical" hide-close-button>Warning MessageStrip With No Close Button</ui5-message-strip>
 	`,
 });
 
@@ -67,10 +67,10 @@ export const messageStripWithNoIcon: Story<MessageStripComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-message-strip design="Information" [hideIcon]="true">Information MessageStrip With No Icon</ui5-message-strip>
-		<ui5-message-strip design="Positive" [hideIcon]="true">Positive MessageStrip With No Icon</ui5-message-strip>
-		<ui5-message-strip design="Negative" [hideIcon]="true">Negative MessageStrip With No Icon</ui5-message-strip>
-		<ui5-message-strip design="Critical" [hideIcon]="true">Warning MessageStrip With No Icon</ui5-message-strip>
+		<ui5-message-strip design="Information" hide-icon>Information MessageStrip With No Icon</ui5-message-strip>
+		<ui5-message-strip design="Positive" hide-icon>Positive MessageStrip With No Icon</ui5-message-strip>
+		<ui5-message-strip design="Negative" hide-icon>Negative MessageStrip With No Icon</ui5-message-strip>
+		<ui5-message-strip design="Critical" hide-icon>Warning MessageStrip With No Icon</ui5-message-strip>
 	`,
 });
 
@@ -79,9 +79,9 @@ export const customMessageStrip: Story<MessageStripComponent> = (
 ) => ({
   props: args,
   template: `
-    <ui5-message-strip style="width: 200px;" design="Information" [hideIcon]="true" [hideCloseButton]="true">You have new message.</ui5-message-strip>
-    <ui5-message-strip style="width: 200px;" design="Positive" [hideCloseButton]="true">Successfull login!</ui5-message-strip>
-    <ui5-message-strip style="width: 200px;" design="Negative" [hideIcon]="true">Access denied!</ui5-message-strip>
+    <ui5-message-strip style="width: 200px;" design="Information" hide-icon hide-close-button>You have new message.</ui5-message-strip>
+    <ui5-message-strip style="width: 200px;" design="Positive" hide-close-button>Successfull login!</ui5-message-strip>
+    <ui5-message-strip style="width: 200px;" design="Negative" hide-icon>Access denied!</ui5-message-strip>
     <ui5-message-strip style="width: 200px;" design="Critical">Update is required.</ui5-message-strip>
     <ui5-message-strip style="width: 200px;" design="Critical"><ui5-icon name="palette" slot="icon"></ui5-icon>Custom icon</ui5-message-strip>
     <ui5-message-strip style="width: 200px;" design="Positive"><img src="../../../assets/images/loading.gif" width="16" height="16" slot="icon">Custom animated gif</ui5-message-strip>

--- a/apps/documentation/src/app/stories/main/multicombobox.stories.ts
+++ b/apps/documentation/src/app/stories/main/multicombobox.stories.ts
@@ -48,13 +48,13 @@ export const basicMultiComboBox: Story<MultiComboBoxComponent> = (
   props: args,
   template: `
 		<ui5-multi-combobox placeholder="Type your value">
-			<ui5-mcb-item [selected]="true" text="UI5"></ui5-mcb-item>
+			<ui5-mcb-item selected text="UI5"></ui5-mcb-item>
 		</ui5-multi-combobox>
-		<ui5-multi-combobox [readonly]="true" value="Readonly combo">
-			<ui5-mcb-item [selected]="true" text="UI5"></ui5-mcb-item>
+		<ui5-multi-combobox readonly value="Readonly combo">
+			<ui5-mcb-item selected text="UI5"></ui5-mcb-item>
 		</ui5-multi-combobox>
-		<ui5-multi-combobox [disabled]="true" value="Disabled combo">
-			<ui5-mcb-item [selected]="true" text="UI5"></ui5-mcb-item>
+		<ui5-multi-combobox disabled value="Disabled combo">
+			<ui5-mcb-item selected text="UI5"></ui5-mcb-item>
 		</ui5-multi-combobox>
 	`,
 });
@@ -65,7 +65,7 @@ export const multiComboBoxWithItems: Story<MultiComboBoxComponent> = (
   props: args,
   template: `
 		<ui5-multi-combobox style="width: 100%" placeholder="Choose your countries">
-			<ui5-mcb-item [selected]="true" text="Argentina"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Argentina"></ui5-mcb-item>
 			<ui5-mcb-item text="Bulgaria"></ui5-mcb-item>
 			<ui5-mcb-item text="Denmark"></ui5-mcb-item>
 			<ui5-mcb-item text="England"></ui5-mcb-item>
@@ -84,15 +84,15 @@ export const multiComboBoxWithFreeTextInput: Story<MultiComboBoxComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-multi-combobox style="width: 100%" placeholder="Choose your countries" [allowCustomValues]="true">
+		<ui5-multi-combobox style="width: 100%" placeholder="Choose your countries" allow-custom-values>
 			<ui5-mcb-item text="Argentina"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="Bulgaria"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Bulgaria"></ui5-mcb-item>
 			<ui5-mcb-item text="Denmark"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="England"></ui5-mcb-item>
+			<ui5-mcb-item selected text="England"></ui5-mcb-item>
 			<ui5-mcb-item text="Albania"></ui5-mcb-item>
 			<ui5-mcb-item text="Morocco"></ui5-mcb-item>
 			<ui5-mcb-item text="Portugal"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="Germany"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Germany"></ui5-mcb-item>
 			<ui5-mcb-item text="Philippines"></ui5-mcb-item>
 			<ui5-mcb-item text="Paraguay"></ui5-mcb-item>
 		</ui5-multi-combobox>
@@ -107,18 +107,18 @@ export const multiComboBoxWithValueState: Story<MultiComboBoxComponent> = (
 		<ui5-multi-combobox value-state="Positive">
 			<ui5-mcb-item text="Fortune"></ui5-mcb-item>
 			<ui5-mcb-item text="Luck"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="Positive"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Positive"></ui5-mcb-item>
 		</ui5-multi-combobox>
 		
 		<ui5-multi-combobox value-state="Critical">
 			<ui5-mcb-item text="Attention"></ui5-mcb-item>
 			<ui5-mcb-item text="Caution"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="Critical"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Critical"></ui5-mcb-item>
 		</ui5-multi-combobox>
 		
 		<ui5-multi-combobox value-state="Negative">
 			<ui5-mcb-item text="Fault"></ui5-mcb-item>
-			<ui5-mcb-item [selected]="true" text="Negative"></ui5-mcb-item>
+			<ui5-mcb-item selected text="Negative"></ui5-mcb-item>
 			<ui5-mcb-item text="Mistake"></ui5-mcb-item>
 		</ui5-multi-combobox>
 	`,

--- a/apps/documentation/src/app/stories/main/multiinput.stories.ts
+++ b/apps/documentation/src/app/stories/main/multiinput.stories.ts
@@ -36,7 +36,7 @@ export const basicMultiInput: Story<MultiInputComponent> = (
   props: args,
   template: `
 		<ui5-multi-input value="basic input"></ui5-multi-input>
-		<ui5-multi-input [showValueHelpIcon]="true" value="value help icon"></ui5-multi-input>
+		<ui5-multi-input show-value-help-icon value="value help icon"></ui5-multi-input>
 	`,
 });
 

--- a/apps/documentation/src/app/stories/main/panel.stories.ts
+++ b/apps/documentation/src/app/stories/main/panel.stories.ts
@@ -83,7 +83,7 @@ export const fixedPanelCantBeCollapsedExpanded: Story<PanelComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-panel [fixed]="true" accessible-role="Complementary" header-text="Country Of Birth">
+		<ui5-panel fixed accessible-role="Complementary" header-text="Country Of Birth">
 			<ui5-list mode="SingleSelectBegin">
 				<ui5-li key="country1">Argentina</ui5-li>
 				<ui5-li key="country2">Bulgaria</ui5-li>

--- a/apps/documentation/src/app/stories/main/progressindicator.stories.ts
+++ b/apps/documentation/src/app/stories/main/progressindicator.stories.ts
@@ -37,7 +37,7 @@ export const basicProgressIndicator: Story<ProgressIndicatorComponent> = (
   template: `
         <ui5-progress-indicator value="0"></ui5-progress-indicator>
         <ui5-progress-indicator value="25"></ui5-progress-indicator>
-        <ui5-progress-indicator value="75" [disabled]="true"></ui5-progress-indicator>
+        <ui5-progress-indicator value="75" disabled></ui5-progress-indicator>
         <ui5-progress-indicator value="100"></ui5-progress-indicator>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/radiobutton.stories.ts
+++ b/apps/documentation/src/app/stories/main/radiobutton.stories.ts
@@ -39,14 +39,14 @@ export const basicRadioButtonTypes: Story<RadioButtonComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-radio-button text="Option A" [checked]="true" name="GroupA"></ui5-radio-button>
+		<ui5-radio-button text="Option A" checked name="GroupA"></ui5-radio-button>
 		<ui5-radio-button text="Option B" value-state="None" name="GroupA"></ui5-radio-button>
 		<ui5-radio-button text="Option C" value-state="Critical" name="GroupA"></ui5-radio-button>
 		<ui5-radio-button text="Option D" value-state="Negative" name="GroupA"></ui5-radio-button>
 		<ui5-radio-button text="Option C" value-state="Positive" name="GroupA"></ui5-radio-button>
 		<ui5-radio-button text="Option D" value-state="Information" name="GroupA"></ui5-radio-button>
-		<ui5-radio-button text="Option E" [disabled]="true" name="GroupA"></ui5-radio-button>
-		<ui5-radio-button text="Option F" [readonly]="true" name="GroupA"></ui5-radio-button>
+		<ui5-radio-button text="Option E" disabled name="GroupA"></ui5-radio-button>
+		<ui5-radio-button text="Option F" readonly name="GroupA"></ui5-radio-button>
 	`,
 });
 
@@ -56,19 +56,17 @@ export const radioButtonInGroupNavigateViaUpRightAndDownLeftArrowKeys: Story<
   props: args,
   template: `
 		<div aria-labelledby="radioGroupTitle1" role="radiogroup" id="radioGroup">
-			<ui5-title id="radioGroupTitle1">Group of states</ui5-title>
-			<ui5-label id="lblRadioGroup">Selected radio: None</ui5-label>
-			<ui5-radio-button text="None" value-state="None" [checked]="true" name="GroupB"></ui5-radio-button>
+			<ui5-title level="H5">Group of states</ui5-title>
+			<ui5-radio-button text="None" value-state="None" name="GroupB"></ui5-radio-button>
 			<ui5-radio-button text="Critical" value-state="Critical" name="GroupB"></ui5-radio-button>
-			<ui5-radio-button text="Negative" value-state="Negative" name="GroupB"></ui5-radio-button>
+			<ui5-radio-button checked text="Negative" value-state="Negative" name="GroupB"></ui5-radio-button>
 			<ui5-radio-button text="Positive" value-state="Positive" name="GroupB"></ui5-radio-button>
 			<ui5-radio-button text="Information" value-state="Information" name="GroupB"></ui5-radio-button>
 		</div>
 		<div aria-labelledby="radioGroupTitle2" role="radiogroup" id="radioGroup2">
-			<ui5-title id="radioGroupTitle2">Group of options</ui5-title>
-			<ui5-label id="lblRadioGroup2">Selected radio: Option A</ui5-label>
-			<ui5-radio-button text="Option A" [checked]="true" name="GroupC"></ui5-radio-button>
-			<ui5-radio-button text="Option B" value-state="None" name="GroupC"></ui5-radio-button>
+			<ui5-title level="H5">Group of options</ui5-title>
+			<ui5-radio-button text="Option A" name="GroupC"></ui5-radio-button>
+			<ui5-radio-button checked text="Option B" value-state="None" name="GroupC"></ui5-radio-button>
 			<ui5-radio-button text="Option C" value-state="None" name="GroupC"></ui5-radio-button>
 		</div>
 	`,

--- a/apps/documentation/src/app/stories/main/rangeslider.stories.ts
+++ b/apps/documentation/src/app/stories/main/rangeslider.stories.ts
@@ -5,21 +5,28 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview Represents a numerical interval and two handles (grips) to select a sub-range within it. The purpose of the component to enable visual selection of sub-ranges within a given interval.
+const description = `
+### Overview 
 
-<h3>Structure</h3> The most important properties of the Range Slider are: <ul> <li>min - The minimum value of the slider range.</li> <li>max - The maximum value of the slider range.</li> <li>value - The current value of the slider.</li> <li>step - Determines the increments in which the slider will move.</li> <li>showTooltip - Determines if a tooltip should be displayed above the handle.</li> <li>showTickmarks - Displays a visual divider between the step values.</li> <li>labelInterval - Labels some or all of the tickmarks with their values.</li> </ul> <h4>Notes:</h4> <ul> <li>The right and left handle can be moved individually and their positions could therefore switch.</li> <li>The entire range can be moved along the interval.</li> </ul> <h3>Usage</h3> The most common use case is to select and move sub-ranges on a continuous numerical scale.
+Represents a numerical interval and two handles (grips) to select a sub-range within it. The purpose of the component to enable visual selection of sub-ranges within a given interval.
 
-<h3>Responsive Behavior</h3> You can move the currently selected range by clicking on it and dragging it along the interval.
+### Structure 
 
-<h3>CSS Shadow Parts</h3>
+The most important properties of the Range Slider are: <ul> <li>min - The minimum value of the slider range.</li> <li>max - The maximum value of the slider range.</li> <li>value - The current value of the slider.</li> <li>step - Determines the increments in which the slider will move.</li> <li>showTooltip - Determines if a tooltip should be displayed above the handle.</li> <li>showTickmarks - Displays a visual divider between the step values.</li> <li>labelInterval - Labels some or all of the tickmarks with their values.</li> </ul> <h4>Notes:</h4> <ul> <li>The right and left handle can be moved individually and their positions could therefore switch.</li> <li>The entire range can be moved along the interval.</li> </ul> ### Usage The most common use case is to select and move sub-ranges on a continuous numerical scale.
+
+### Responsive Behavior 
+
+You can move the currently selected range by clicking on it and dragging it along the interval.
+
+### CSS Shadow Parts
 
 <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM. <br> The <code>ui5-range-slider</code> exposes the following CSS Shadow Parts: <ul> <li>progress-container - Used to style the progress container(the horizontal bar which visually represents the range between the minimum and maximum value) of the <code>ui5-range-slider</code>.</li> <li>progress-bar - Used to style the progress bar, which shows the progress of the <code>ui5-range-slider</code>.</li> <li>handle - Used to style the handles of the <code>ui5-range-slider</code>.</li> </ul>
 
-<h3>Keyboard Handling</h3>
+### Keyboard Handling
 
 <ul> <li><code>Left or Down Arrow</code> - Moves a component's handle or the entire selection one step to the left;</li> <li><code>Right or Up Arrow</code> - Moves a component's handle or the entire selection one step to the right;</li> <li><code>Left or Down Arrow + Ctrl/Cmd</code> - Moves a component's handle to the left or the entire range with step equal to 1/10th of the entire range;</li> <li><code>Right or Up Arrow + Ctrl/Cmd</code> - Moves a component's handle to the right or the entire range with step equal to 1/10th of the entire range;</li> <li><code>Plus</code> - Same as <code>Right or Up Arrow</code>;</li> <li><code>Minus</code> - Same as <code>Left or Down Arrow</code>;</li> <li><code>Home</code> - Moves the entire selection or the selected handle to the beginning of the component's range;</li> <li><code>End</code> - Moves the entire selection or the selected handle to the end of the component's range;</li> <li><code>Page Up</code> - Same as <code>Right or Up Arrow + Ctrl/Cmd</code>;</li> <li><code>Page Down</code> - Same as <code>Left or Down Arrow + Ctrl/Cmd</code>;</li> <li><code>Escape</code> - Resets the <code>startValue</code> and <code>endValue</code> properties to the values prior the component focusing;</li> </ul>
 
-<h3>ES6 Module Import</h3>
+### ES6 Module Import
 
 <code>import { RangeSliderComponent } from "@ui5/webcomponents-ngx/main/range-slider";</code>`;
 export default {
@@ -63,7 +70,7 @@ export const rangeSliderWithTooltips: Story<RangeSliderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-range-slider [startValue]="3" [endValue]="13" [showTooltip]="true"></ui5-range-slider>
+		<ui5-range-slider [startValue]="3" [endValue]="13" show-tooltip></ui5-range-slider>
 	`,
 });
 
@@ -72,7 +79,7 @@ export const rangeSliderWithTickmarksAndCustomStep: Story<
 > = (args: RangeSliderComponent & any) => ({
   props: args,
   template: `
-		<ui5-range-slider step="2" [startValue]="12" [endValue]="24" [showTickmarks]="true"></ui5-range-slider>
+		<ui5-range-slider step="2" [startValue]="12" [endValue]="24" show-tickmarks></ui5-range-slider>
 	`,
 });
 
@@ -81,6 +88,6 @@ export const rangeSliderWithTooltipsTickmarksAndLabels: Story<
 > = (args: RangeSliderComponent & any) => ({
   props: args,
   template: `
-		<ui5-range-slider [min]="0" [max]="112" [step]="2" [startValue]="4" [endValue]="12" [showTooltip]="true" [labelInterval]="2" [showTickmarks]="true"></ui5-range-slider>
+		<ui5-range-slider [min]="0" [max]="112" [step]="2" [startValue]="4" [endValue]="12" show-tooltip [labelInterval]="2" show-tickmarks></ui5-range-slider>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/ratingindicator.stories.ts
+++ b/apps/documentation/src/app/stories/main/ratingindicator.stories.ts
@@ -5,17 +5,26 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The Rating Indicator is used to display a specific number of icons that are used to rate an item. Additionally, it is also used to display the average and overall ratings.
+const description = `
+### Overview 
 
-<h3>Usage</h3> The recommended number of icons is between 5 and 7.
+The Rating Indicator is used to display a specific number of icons that are used to rate an item. Additionally, it is also used to display the average and overall ratings.
 
-<h3>Responsive Behavior</h3> You can change the size of the Rating Indicator by changing its <code>font-size</code> CSS property. <br> Example: <code>&lt;ui5-rating-indicator style="font-size: 3rem;">&lt;/ui5-rating-indicator></code>
+### Usage</h3> 
 
-<h3>Keyboard Handling</h3> When the <code>ui5-rating-indicator</code> is focused, the user can change the rating with the following keyboard shortcuts: <br>
+The recommended number of icons is between 5 and 7.
+
+### Responsive Behavior</h3> 
+
+You can change the size of the Rating Indicator by changing its <code>font-size</code> CSS property. <br> Example: <code>&lt;ui5-rating-indicator style="font-size: 3rem;">&lt;/ui5-rating-indicator></code>
+
+### Keyboard Handling</h3> 
+
+When the <code>ui5-rating-indicator</code> is focused, the user can change the rating with the following keyboard shortcuts: <br>
 
 <ul> <li>[RIGHT/UP] - Increases the value of the rating by one step. If the highest value is reached, does nothing</li> <li>[LEFT/DOWN] - Decreases the value of the rating by one step. If the lowest value is reached, does nothing.</li> <li>[HOME] - Sets the lowest value.</li> <li>[END] - Sets the highest value.</li> <li>[SPACE/ENTER/RETURN] - Increases the value of the rating by one step. If the highest value is reached, sets the rating to the lowest value.</li> <li>Any number - Changes value to the corresponding number. If typed number is larger than the number of values, sets the highest value.</li> </ul>
 
-<h3>ES6 Module Import</h3>
+### ES6 Module Import</h3>
 
 <code>import { RatingIndicatorComponent } from "@ui5/webcomponents-ngx/main/rating-indicator";</code>`;
 export default {
@@ -62,9 +71,9 @@ export const disabledRatingIndicator: Story<RatingIndicatorComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-rating-indicator value="4" [disabled]="true"></ui5-rating-indicator>
-		<ui5-rating-indicator max="10" value="5" [disabled]="true"></ui5-rating-indicator>
-		<ui5-rating-indicator max="3" value="3" [disabled]="true"></ui5-rating-indicator>
+		<ui5-rating-indicator value="4" disabled></ui5-rating-indicator>
+		<ui5-rating-indicator max="10" value="5" disabled></ui5-rating-indicator>
+		<ui5-rating-indicator max="3" value="3" disabled></ui5-rating-indicator>
 	`,
 });
 
@@ -73,7 +82,7 @@ export const readonlyRatingIndicator: Story<RatingIndicatorComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-rating-indicator value="4" [readonly]="true"></ui5-rating-indicator>
-		<ui5-rating-indicator max="7" value="5" [readonly]="true"></ui5-rating-indicator>
+		<ui5-rating-indicator value="4" readonly></ui5-rating-indicator>
+		<ui5-rating-indicator max="7" value="5" readonly></ui5-rating-indicator>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/responsivepopover.stories.ts
+++ b/apps/documentation/src/app/stories/main/responsivepopover.stories.ts
@@ -5,11 +5,16 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The <code>ui5-responsive-popover</code> acts as a Popover on desktop and tablet, while on phone it acts as a Dialog. The component improves tremendously the user experience on mobile.
+const description = `
+### Overview 
 
-<h3>Usage</h3> Use it when you want to make sure that all the content is visible on any device.
+The <code>ui5-responsive-popover</code> acts as a Popover on desktop and tablet, while on phone it acts as a Dialog. The component improves tremendously the user experience on mobile.
 
-<h3>CSS Shadow Parts</h3>
+### Usage 
+
+Use it when you want to make sure that all the content is visible on any device.
+
+### CSS Shadow Parts
 
 <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM. <br> The <code>ui5-responsive-popover</code> exposes the following CSS Shadow Parts: <ul> <li>header - Used to style the header of the component</li> <li>content - Used to style the content of the component</li> <li>footer - Used to style the footer of the component</li> </ul>`;
 export default {

--- a/apps/documentation/src/app/stories/main/segmentedbutton.stories.ts
+++ b/apps/documentation/src/app/stories/main/segmentedbutton.stories.ts
@@ -37,7 +37,7 @@ export const basicSegmentedButton: Story<SegmentedButtonComponent> = (
   template: `
         <ui5-segmented-button accessible-name="Geographic location">
             <ui5-segmented-button-item>Map</ui5-segmented-button-item>
-            <ui5-segmented-button-item [selected]="true">Satellite</ui5-segmented-button-item>
+            <ui5-segmented-button-item selected>Satellite</ui5-segmented-button-item>
             <ui5-segmented-button-item>Terrain</ui5-segmented-button-item>
         </ui5-segmented-button>
 	`,
@@ -49,7 +49,7 @@ export const segmentedButtonWithIcons: Story<SegmentedButtonComponent> = (
   props: args,
   template: `
 		<ui5-segmented-button>
-			<ui5-segmented-button-item icon="employee" [selected]="true"></ui5-segmented-button-item>
+			<ui5-segmented-button-item icon="employee" selected></ui5-segmented-button-item>
 			<ui5-segmented-button-item icon="menu"></ui5-segmented-button-item>
 			<ui5-segmented-button-item icon="factory"></ui5-segmented-button-item>
 		</ui5-segmented-button>
@@ -63,7 +63,7 @@ export const segmentedButtonWith5SegmentedButtonItems: Story<
   template: `
 		<ui5-segmented-button>
 			<ui5-segmented-button-item>Item</ui5-segmented-button-item>
-			<ui5-segmented-button-item [selected]="true">Pressed SegmentedButtonItem With Bigger Text</ui5-segmented-button-item>
+			<ui5-segmented-button-item selected>Pressed SegmentedButtonItem With Bigger Text</ui5-segmented-button-item>
 			<ui5-segmented-button-item>Item</ui5-segmented-button-item>
 			<ui5-segmented-button-item>SegmentedButtonItem</ui5-segmented-button-item>
 			<ui5-segmented-button-item>Press me</ui5-segmented-button-item>

--- a/apps/documentation/src/app/stories/main/select.stories.ts
+++ b/apps/documentation/src/app/stories/main/select.stories.ts
@@ -36,7 +36,7 @@ export const basicSelect: Story<SelectComponent> = (
 		<ui5-select>
 			<ui5-option icon="iphone">Phone</ui5-option>
 			<ui5-option icon="ipad">Tablet</ui5-option>
-			<ui5-option icon="laptop" [selected]="true">Desktop</ui5-option>
+			<ui5-option icon="laptop" selected>Desktop</ui5-option>
 		</ui5-select>
 	`,
 });
@@ -47,13 +47,13 @@ export const selectWithValueStateAndValueStateMessage: Story<
   props: args,
   template: `
 		<ui5-select value-state="Positive">
-				<ui5-option icon="meal" [selected]="true">Apple</ui5-option>
+				<ui5-option icon="meal" selected>Apple</ui5-option>
 				<ui5-option icon="meal">Avocado</ui5-option>
 				<ui5-option icon="meal">Mango</ui5-option>
 		</ui5-select>
 		<ui5-select value-state="Critical">
 				<ui5-option icon="meal">Orange</ui5-option>
-				<ui5-option icon="meal" [selected]="true">Pumpkin</ui5-option>
+				<ui5-option icon="meal" selected>Pumpkin</ui5-option>
 				<ui5-option icon="meal">Carrot</ui5-option>
 				<div slot="valueStateMessage">Information message. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 				<div slot="valueStateMessage">Information message 2. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
@@ -61,14 +61,14 @@ export const selectWithValueStateAndValueStateMessage: Story<
 		<ui5-select value-state="Negative">
 				<ui5-option icon="meal">Strawberry</ui5-option>
 				<ui5-option icon="meal">Tomato</ui5-option>
-				<ui5-option icon="meal" [selected]="true">Red Chili Pepper</ui5-option>
+				<ui5-option icon="meal" selected>Red Chili Pepper</ui5-option>
 				<div slot="valueStateMessage">Information message. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 				<div slot="valueStateMessage">Information message 2. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 		</ui5-select>
 		<ui5-select value-state="Information">
 			<ui5-option icon="meal">Blueberry</ui5-option>
 			<ui5-option icon="meal">Grape</ui5-option>
-			<ui5-option icon="meal" [selected]="true">Plum</ui5-option>
+			<ui5-option icon="meal" selected>Plum</ui5-option>
 			<div slot="valueStateMessage">Information message. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 			<div slot="valueStateMessage">Information message 2. This is a <a href="#">Link</a>. Extra long text used as an information message. Extra long text used as an information message - 2. Extra long text used as an information message - 3.</div>
 		</ui5-select>

--- a/apps/documentation/src/app/stories/main/slider.stories.ts
+++ b/apps/documentation/src/app/stories/main/slider.stories.ts
@@ -5,23 +5,32 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The Slider component represents a numerical range and a handle (grip). The purpose of the component is to enable visual selection of a value in a continuous numerical range by moving an adjustable handle.
+const description = `
+### Overview 
 
-<h3>Structure</h3> The most important properties of the Slider are: <ul> <li>min - The minimum value of the slider range.</li> <li>max - The maximum value of the slider range.</li> <li>value - The current value of the slider range.</li> <li>step - Determines the increments in which the slider will move.</li> <li>showTooltip - Determines if a tooltip should be displayed above the handle.</li> <li>showTickmarks - Displays a visual divider between the step values.</li> <li>labelInterval - Labels some or all of the tickmarks with their values.</li> </ul>
+The Slider component represents a numerical range and a handle (grip). The purpose of the component is to enable visual selection of a value in a continuous numerical range by moving an adjustable handle.
 
-<h3>Usage</h3> The most common use case is to select values on a continuous numerical scale (e.g. temperature, volume, etc. ).
+### Structure
 
-<h3>Responsive Behavior</h3> The <code>ui5-slider</code> component adjusts to the size of its parent container by recalculating and resizing the width of the control. You can move the slider handle in several different ways: <ul> <li>Drag and drop the handle to the desired value.</li> <li>Click/tap on the range bar to move the handle to that location.</li> </ul>
+The most important properties of the Slider are: <ul> <li>min - The minimum value of the slider range.</li> <li>max - The maximum value of the slider range.</li> <li>value - The current value of the slider range.</li> <li>step - Determines the increments in which the slider will move.</li> <li>showTooltip - Determines if a tooltip should be displayed above the handle.</li> <li>showTickmarks - Displays a visual divider between the step values.</li> <li>labelInterval - Labels some or all of the tickmarks with their values.</li> </ul>
 
-<h3>CSS Shadow Parts</h3>
+### Usage
+
+The most common use case is to select values on a continuous numerical scale (e.g. temperature, volume, etc. ).
+
+### Responsive Behavior
+
+The <code>ui5-slider</code> component adjusts to the size of its parent container by recalculating and resizing the width of the control. You can move the slider handle in several different ways: <ul> <li>Drag and drop the handle to the desired value.</li> <li>Click/tap on the range bar to move the handle to that location.</li> </ul>
+
+### CSS Shadow Parts
 
 <ui5-link target="_blank" href="https://developer.mozilla.org/en-US/docs/Web/CSS/::part">CSS Shadow Parts</ui5-link> allow developers to style elements inside the Shadow DOM. <br> The <code>ui5-slider</code> exposes the following CSS Shadow Parts: <ul> <li>progress-container - Used to style the progress container(the horizontal bar which visually represents the range between the minimum and maximum value) of the <code>ui5-slider</code>.</li> <li>progress-bar - Used to style the progress bar, which shows the progress of the <code>ui5-slider</code>.</li> <li>handle - Used to style the handle of the <code>ui5-slider</code>.</li> </ul>
 
-<h3>Keyboard Handling</h3>
+### Keyboard Handling
 
 <ul> <li><code>Left or Down Arrow</code> - Moves the handle one step to the left, effectively decreasing the component's value by <code>step</code> amount;</li> <li><code>Right or Up Arrow</code> - Moves the handle one step to the right, effectively increasing the component's value by <code>step</code> amount;</li> <li><code>Left or Down Arrow + Ctrl/Cmd</code> - Moves the handle to the left with step equal to 1/10th of the entire range, effectively decreasing the component's value by 1/10th of the range;</li> <li><code>Right or Up Arrow + Ctrl/Cmd</code> - Moves the handle to the right with step equal to 1/10th of the entire range, effectively increasing the component's value by 1/10th of the range;</li> <li><code>Plus</code> - Same as <code>Right or Up Arrow</code>;</li> <li><code>Minus</code> - Same as <code>Left or Down Arrow</code>;</li> <li><code>Home</code> - Moves the handle to the beginning of the range;</li> <li><code>End</code> - Moves the handle to the end of the range;</li> <li><code>Page Up</code> - Same as <code>Right or Up + Ctrl/Cmd</code>;</li> <li><code>Page Down</code> - Same as <code>Left or Down + Ctrl/Cmd</code>;</li> <li><code>Escape</code> - Resets the value property after interaction, to the position prior the component's focusing;</li> </ul>
 
-<h3>ES6 Module Import</h3>
+### ES6 Module Import
 
 <code>import { SliderComponent } from "@ui5/webcomponents-ngx/main/slider";</code>`;
 export default {
@@ -56,7 +65,7 @@ export const sliderWithTooltip: Story<SliderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-slider [min]="0" [max]="20" [value]="10" [showTooltip]="true"></ui5-slider>
+		<ui5-slider [min]="0" [max]="20" [value]="10" show-tooltip></ui5-slider>
 	`,
 });
 
@@ -65,7 +74,7 @@ export const disabledSliderWithTickmarksAndLabels: Story<SliderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-slider [min]="20" [max]="100" [labelInterval]="5" [disabled]="true" [showTickmarks]="true"></ui5-slider>
+		<ui5-slider [min]="20" [max]="100" [labelInterval]="5" disabled show-tickmarks></ui5-slider>
 	`,
 });
 
@@ -74,6 +83,6 @@ export const sliderTooltipTickmarksAndLabels: Story<SliderComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-slider [min]="-20" [max]="20" step="2" [value]="12" [showTooltip]="true" [labelInterval]="2" [showTickmarks]="true"></ui5-slider>
+		<ui5-slider [min]="-20" [max]="20" step="2" [value]="12" show-tooltip [labelInterval]="2" show-tickmarks></ui5-slider>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/splitbutton.stories.ts
+++ b/apps/documentation/src/app/stories/main/splitbutton.stories.ts
@@ -5,17 +5,20 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview
+const description = `
+### Overview
 
 <code>ui5-split-button</code> enables users to trigger actions. It is constructed of two separate actions - default action and arrow action that can be activated by clicking or tapping, or by pressing certain keyboard keys - <code>Space</code> or <code>Enter</code> for default action, and <code>Arrow Down</code> or <code>Arrow Up</code> for arrow action.
 
-<h3>Usage</h3>
+### Usage
 
 <code>ui5-split-button</code> consists two separate buttons: <ul> <li>for the first one (default action) you can define some <code>text</code> or an <code>icon</code>, or both. Also, it is possible to define different icon for active state of this button - <code>activeIcon</code>.</li> <li>the second one (arrow action) contains only <code>slim-arrow-down</code> icon.</li> </ul> You can choose a <code>design</code> from a set of predefined types (the same as for ui5-button) that offer different styling to correspond to the triggered action. Both text and arrow actions have the same design. <br><br> You can set the <code>ui5-split-button</code> as enabled or disabled. Both parts of an enabled <code>ui5-split-button</code> can be pressed by clicking or tapping it, or by certain keys, which changes the style to provide visual feedback to the user that it is pressed or hovered over with the mouse cursor. A disabled <code>ui5-split-button</code> appears inactive and any of the two buttons cannot be pressed.
 
-<h3>Keyboard Handling</h3> <ul> <li><code>Space</code> or <code>Enter</code> - triggers the default action</li> <li><code>Shift</code> or <code>Escape</code> - if <code>Space</code> is pressed, releases the default action button without triggering the click event.</li> <li><code>Arrow Down</code>, <code>Arrow Up</code>, <code>Alt</code>+<code>Arrow Down</code>, <code>Alt</code>+<code>Arrow Up</code>, or <code>F4</code> - triggers the arrow action</li> There are separate events that are fired on activating of <code>ui5-split-button</code> parts: <ul> <li><code>click</code> for the first button (default action)</li> <li><code>arrow-click</code> for the second button (arrow action)</li> </ul> </ul>
+### Keyboard Handling 
 
-<h3>ES6 Module Import</h3>
+<ul> <li><code>Space</code> or <code>Enter</code> - triggers the default action</li> <li><code>Shift</code> or <code>Escape</code> - if <code>Space</code> is pressed, releases the default action button without triggering the click event.</li> <li><code>Arrow Down</code>, <code>Arrow Up</code>, <code>Alt</code>+<code>Arrow Down</code>, <code>Alt</code>+<code>Arrow Up</code>, or <code>F4</code> - triggers the arrow action</li> There are separate events that are fired on activating of <code>ui5-split-button</code> parts: <ul> <li><code>click</code> for the first button (default action)</li> <li><code>arrow-click</code> for the second button (arrow action)</li> </ul> </ul>
+
+### ES6 Module Import
 
 <code>import { SplitButtonComponent } from "@ui5/webcomponents-ngx/main/split-button";</code>`;
 export default {
@@ -42,7 +45,7 @@ export const defaultSplitButton: Story<SplitButtonComponent> = (
   props: args,
   template: `
 		<ui5-split-button>Default</ui5-split-button>
-		<ui5-split-button [disabled]="true">Default</ui5-split-button>
+		<ui5-split-button disabled>Default</ui5-split-button>
 	`,
 });
 

--- a/apps/documentation/src/app/stories/main/stepinput.stories.ts
+++ b/apps/documentation/src/app/stories/main/stepinput.stories.ts
@@ -45,8 +45,8 @@ export const basicStepInput: Story<StepInputComponent> = (
   template: `
 		<div>
 			<ui5-step-input [value]="5"></ui5-step-input>
-			<ui5-step-input [readonly]="true" [value]="5"></ui5-step-input>
-			<ui5-step-input [disabled]="true" [value]="5"></ui5-step-input>
+			<ui5-step-input readonly [value]="5"></ui5-step-input>
+			<ui5-step-input disabled [value]="5"></ui5-step-input>
 		</div>
 	`,
 });
@@ -96,7 +96,7 @@ export const stepInputWithLabel: Story<StepInputComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-label for="myStepInput" [required]="true" [showColon]="true">Number</ui5-label>
-		<ui5-step-input id="myStepInput" placeholder="Enter your Number" [required]="true"></ui5-step-input>
+		<ui5-label for="myStepInput" required showColon>Number</ui5-label>
+		<ui5-step-input id="myStepInput" placeholder="Enter your Number" required></ui5-step-input>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/switch.stories.ts
+++ b/apps/documentation/src/app/stories/main/switch.stories.ts
@@ -45,11 +45,11 @@ export const basicSwitch: Story<SwitchComponent> = (
   props: args,
   template: `
 		<ui5-switch text-on="On" text-off="Off"></ui5-switch>
-		<ui5-switch text-on="On" text-off="Off" [checked]="true"></ui5-switch>
+		<ui5-switch text-on="On" text-off="Off" checked></ui5-switch>
 		<ui5-switch></ui5-switch>
-		<ui5-switch [checked]="true"></ui5-switch>
-		<ui5-switch text-on="Yes" text-off="No" [disabled]="true"></ui5-switch>
-		<ui5-switch text-on="Yes" text-off="No" [checked]="true" [disabled]="true"></ui5-switch>
+		<ui5-switch checked></ui5-switch>
+		<ui5-switch text-on="Yes" text-off="No" disabled></ui5-switch>
+		<ui5-switch text-on="Yes" text-off="No" checked disabled></ui5-switch>
 	`,
 });
 
@@ -59,8 +59,8 @@ export const graphicalSwitch: Story<SwitchComponent> = (
   props: args,
   template: `
 		<ui5-switch accessible-name="graphical" design="Graphical"></ui5-switch>
-		<ui5-switch accessible-name="graphical" design="Graphical" [checked]="true"></ui5-switch>
-		<ui5-switch accessible-name="graphical" design="Graphical" [disabled]="true"></ui5-switch>
-		<ui5-switch accessible-name="graphical" design="Graphical" [disabled]="true" [checked]="true"></ui5-switch>
+		<ui5-switch accessible-name="graphical" design="Graphical" checked></ui5-switch>
+		<ui5-switch accessible-name="graphical" design="Graphical" disabled></ui5-switch>
+		<ui5-switch accessible-name="graphical" design="Graphical" disabled checked></ui5-switch>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/tabcontainer.stories.ts
+++ b/apps/documentation/src/app/stories/main/tabcontainer.stories.ts
@@ -53,7 +53,7 @@ export const basicTabContainer: Story<
 			<ui5-tab icon="menu" text="Tab 1">
 				<ui5-label>Quibusdam, veniam! Architecto debitis iusto ad et, asperiores quisquam perferendis reprehenderit ipsa voluptate minus minima, perspiciatis cum. Totam harum necessitatibus numquam voluptatum.</ui5-label>
 			</ui5-tab>
-			<ui5-tab icon="activities" text="Tab 2" [selected]="true">
+			<ui5-tab icon="activities" text="Tab 2" selected>
 				<ui5-label>Lorem ipsum dolor sit amet consectetur adipisicing elit. Fuga magni facere error dicta beatae optio repudiandae vero, quidem voluptatibus perferendis eum maiores rem tempore voluptates aperiam eos enim delectus unde.</ui5-label>
 			</ui5-tab>
 			<ui5-tab icon="add" text="Tab 3">
@@ -75,9 +75,9 @@ export const tabContainerWithTextOnlyTabs: Story<TabContainerComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-tabcontainer [collapsed]="true">
+		<ui5-tabcontainer collapsed>
 			<ui5-tab text="Home"></ui5-tab>
-			<ui5-tab text="What's new" [selected]="true"></ui5-tab>
+			<ui5-tab text="What's new" selected></ui5-tab>
 			<ui5-tab text="Who are we"></ui5-tab>
 			<ui5-tab text="About"></ui5-tab>
 			<ui5-tab text="Contacts"></ui5-tab>
@@ -90,7 +90,7 @@ export const textOnlyEndOverflow: Story<TabContainerComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-tabcontainer [collapsed]="true">
+		<ui5-tabcontainer collapsed>
 			<ui5-tab text="Tab 1">
 			</ui5-tab>
 			<ui5-tab text="Tab 2">
@@ -115,7 +115,7 @@ export const textOnlyEndOverflow: Story<TabContainerComponent> = (
 			</ui5-tab>
 			<ui5-tab text="Tab 12">
 			</ui5-tab>
-			<ui5-tab text="Tab 13" [selected]="true">
+			<ui5-tab text="Tab 13" selected>
 			</ui5-tab>
 			<ui5-tab text="Tab 14">
 			</ui5-tab>
@@ -146,10 +146,10 @@ export const tabContainerWithTextAndAdditionalText: Story<
 > = (args: TabContainerComponent & any) => ({
   props: args,
   template: `
-		<ui5-tabcontainer [collapsed]="true">
+		<ui5-tabcontainer collapsed>
 			<ui5-tab text="Info" additional-text="3">
 			</ui5-tab>
-			<ui5-tab text="Attachments" additional-text="24" [selected]="true">
+			<ui5-tab text="Attachments" additional-text="24" selected>
 			</ui5-tab>
 			<ui5-tab text="Notes" additional-text="16">
 			</ui5-tab>
@@ -164,19 +164,19 @@ export const tabContainerWithTabLayoutInline: Story<TabContainerComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-tabcontainer tab-layout="Inline" [collapsed]="true">
+		<ui5-tabcontainer tab-layout="Inline" collapsed>
 			<ui5-tab text="Monitors" additional-text="10">
 			</ui5-tab>
-			<ui5-tab text="Cameras" additional-text="2" [selected]="true">
+			<ui5-tab text="Cameras" additional-text="2" selected>
 			</ui5-tab>
 			<ui5-tab text="Rooms" additional-text="16">
 			</ui5-tab>
 		</ui5-tabcontainer>
 
-		<ui5-tabcontainer tab-layout="Inline" [collapsed]="true">
+		<ui5-tabcontainer tab-layout="Inline" collapsed>
 			<ui5-tab icon="laptop" text="Monitors" additional-text="10">
 			</ui5-tab>
-			<ui5-tab icon="video" text="Cameras" additional-text="2" [selected]="true">
+			<ui5-tab icon="video" text="Cameras" additional-text="2" selected>
 			</ui5-tab>
 			<ui5-tab icon="home" text="Rooms" additional-text="16">
 			</ui5-tab>
@@ -189,7 +189,7 @@ export const tabContainerWithNestedTabs: Story<TabContainerComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-tabcontainer [collapsed]="true">
+		<ui5-tabcontainer collapsed>
 			<ui5-tab text="Notes">
 				Notes go here ...
 			</ui5-tab>

--- a/apps/documentation/src/app/stories/main/textarea.stories.ts
+++ b/apps/documentation/src/app/stories/main/textarea.stories.ts
@@ -48,7 +48,7 @@ export const textAreaWithMaximumLength: Story<TextAreaComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-textarea class="textarea-width" placeholder="Type no more than 10 symbols" [maxlength]="10" [showExceededText]="true"></ui5-textarea>
+		<ui5-textarea class="textarea-width" placeholder="Type no more than 10 symbols" [maxlength]="10" show-exceeded-text></ui5-textarea>
 	`,
 });
 

--- a/apps/documentation/src/app/stories/main/togglebutton.stories.ts
+++ b/apps/documentation/src/app/stories/main/togglebutton.stories.ts
@@ -36,15 +36,15 @@ export const toggleButtonStates: Story<ToggleButtonComponent> = (
   props: args,
   template: `
 		<ui5-toggle-button class="samples-margin">ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" [pressed]="true">Pressed ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" [disabled]="true">Disabled ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" [disabled]="true" [pressed]="true">Disabled and Pressed ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" pressed>Pressed ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" disabled>Disabled ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" disabled pressed>Disabled and Pressed ToggleButton</ui5-toggle-button>
 		<ui5-toggle-button class="samples-margin" design="Positive">Accept ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" design="Positive" [pressed]="true">Pressed Accept ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" design="Positive" pressed>Pressed Accept ToggleButton</ui5-toggle-button>
 		<ui5-toggle-button class="samples-margin" design="Negative">Reject ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" design="Negative" [pressed]="true">Pressed Reject ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" design="Negative" pressed>Pressed Reject ToggleButton</ui5-toggle-button>
 		<ui5-toggle-button class="samples-margin" design="Transparent">Transparent ToggleButton</ui5-toggle-button>
-		<ui5-toggle-button class="samples-margin" design="Transparent" [pressed]="true">Pressed Transparent ToggleButton</ui5-toggle-button>
+		<ui5-toggle-button class="samples-margin" design="Transparent" pressed>Pressed Transparent ToggleButton</ui5-toggle-button>
 	`,
 });
 
@@ -67,15 +67,15 @@ export const toggleButtonWithIconOnly: Story<ToggleButtonComponent> = (
   props: args,
   template: `
 			<ui5-toggle-button class="samples-margin" icon="away"></ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" icon="action-settings" [pressed]="true"></ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" icon="action-settings" pressed></ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" icon="add"></ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" icon="alert" [pressed]="true"></ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" icon="alert" pressed></ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" icon="accept" design="Positive"></ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" icon="bookmark" design="Positive" [pressed]="true"></ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" icon="bookmark" design="Positive" pressed></ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" icon="cancel" design="Negative"></ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" icon="call" design="Negative" [pressed]="true"></ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" icon="call" design="Negative" pressed></ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" icon="camera" design="Transparent"></ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" icon="cart" design="Transparent" [pressed]="true"></ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" icon="cart" design="Transparent" pressed></ui5-toggle-button>
 	`,
 });
 
@@ -85,14 +85,14 @@ export const toggleButton: Story<ToggleButtonComponent> = (
   props: args,
   template: `
 			<ui5-toggle-button class="samples-margin">Yes/No</ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" [pressed]="true">Yes/No</ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" pressed>Yes/No</ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin">Toggle Button</ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" [pressed]="true">Toggle Button pressed</ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" pressed>Toggle Button pressed</ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" design="Positive">On/Off</ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" design="Positive" [pressed]="true">On/Off</ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" design="Positive" pressed>On/Off</ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" design="Negative">Menu</ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" design="Negative" [pressed]="true">Menu</ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" design="Negative" pressed>Menu</ui5-toggle-button>
 			<ui5-toggle-button class="samples-margin" design="Transparent">Transparent</ui5-toggle-button>
-			<ui5-toggle-button class="samples-margin" design="Transparent" [pressed]="true">Transparent</ui5-toggle-button>
+			<ui5-toggle-button class="samples-margin" design="Transparent" pressed>Transparent</ui5-toggle-button>
 	`,
 });

--- a/apps/documentation/src/app/stories/main/tree.stories.ts
+++ b/apps/documentation/src/app/stories/main/tree.stories.ts
@@ -38,9 +38,9 @@ export default {
 export const basicTree: Story<TreeComponent> = (args: TreeComponent & any) => ({
   props: args,
   template: `
-		<ui5-tree id="myTree" class="full-width">
-			<ui5-tree-item [expanded]="true" text="Tree 1" icon="paste" [selected]="true">
-				<ui5-tree-item [expanded]="true" text="Tree 1.1" [selected]="true">
+		<ui5-tree>
+			<ui5-tree-item expanded text="Tree 1" icon="paste" selected>
+				<ui5-tree-item expanded text="Tree 1.1" selected>
 					<ui5-tree-item text="Tree 1.1.1"></ui5-tree-item>
 					<ui5-tree-item text="Tree 1.1.2"></ui5-tree-item>
 				</ui5-tree-item>
@@ -58,7 +58,7 @@ export const basicTree: Story<TreeComponent> = (args: TreeComponent & any) => ({
 				<ui5-tree-item text="Tree 2.2"></ui5-tree-item>
 			</ui5-tree-item>
 
-			<ui5-tree-item [expanded]="true" text="Tree 3 (no icon)">
+			<ui5-tree-item expanded text="Tree 3 (no icon)">
 			</ui5-tree-item>
 		</ui5-tree>
 	`,
@@ -69,9 +69,9 @@ export const treeWithMultipleSelection: Story<TreeComponent> = (
 ) => ({
   props: args,
   template: `
-		<ui5-tree id="myTree" class="full-width" mode="MultiSelect">
-			<ui5-tree-item [expanded]="true" text="Tree 1" icon="paste" [selected]="true">
-				<ui5-tree-item [expanded]="true" text="Tree 1.1" [selected]="true">
+		<ui5-tree selection-mode="Multiple">
+			<ui5-tree-item expanded text="Tree 1" icon="paste" selected>
+				<ui5-tree-item expanded text="Tree 1.1" selected>
 					<ui5-tree-item text="Tree 1.1.1"></ui5-tree-item>
 					<ui5-tree-item text="Tree 1.1.2"></ui5-tree-item>
 				</ui5-tree-item>
@@ -89,31 +89,12 @@ export const treeWithMultipleSelection: Story<TreeComponent> = (
 				<ui5-tree-item text="Tree 2.2"></ui5-tree-item>
 			</ui5-tree-item>
 
-			<ui5-tree-item [expanded]="true" text="Tree 3 (no icon)">
+			<ui5-tree-item expanded text="Tree 3 (no icon)">
 			</ui5-tree-item>
 		</ui5-tree>
 	`,
 });
 
-export const treeWithDynamicContent: Story<TreeComponent> = (
-  args: TreeComponent & any
-) => ({
-  props: args,
-  template: `
-		<ui5-busy-indicator id="busy" class="full-width">
-			<ui5-tree id="treeDynamic" mode="None" class="full-width">
-				<ui5-tree-item text="Has pre-loaded children">
-					<ui5-tree-item text="Child 1"></ui5-tree-item>
-					<ui5-tree-item text="Child 2"></ui5-tree-item>
-				</ui5-tree-item>
-
-				<ui5-tree-item text="Has no children at all"></ui5-tree-item>
-
-				<ui5-tree-item id="dynamicNode" text="Has children, but not yet loaded" [hasChildren]="true"></ui5-tree-item>
-			</ui5-tree>
-		</ui5-busy-indicator>
-	`,
-});
 
 export const treeWithCustomItems: Story<TreeComponent> = (
   args: TreeComponent & any
@@ -121,20 +102,20 @@ export const treeWithCustomItems: Story<TreeComponent> = (
   props: args,
   template: `
 		<ui5-tree mode="MultiSelect">
-			<div slot="header" class="hdr">
-				<ui5-title>Tree with custom items</ui5-title>
+			<div slot="header">
+				<ui5-title level="H4">Tree with custom items</ui5-title>
 			</div>
-			<ui5-tree-item-custom expanded="true" [showToggleButton]="true" [hideSelectionElement]="true" type="Active" level="1">
+			<ui5-tree-item-custom expanded show-toggle-button hide-selection-element type="Active" level="1">
 				<ui5-button slot="content">Level 1</ui5-button>
 		
-				<ui5-tree-item-custom type="Active" [showToggleButton]="true" level="2" [expanded]="true">
+				<ui5-tree-item-custom type="Active" show-toggle-button level="2" expanded>
 					<ui5-select slot="content">
 						<ui5-option>Level 2</ui5-option>
 						<ui5-option>Option 2.1</ui5-option>
 						<ui5-option>Option 2.3</ui5-option>
 					</ui5-select>
 		
-					<ui5-tree-item-custom [hideSelectionElement]="true" type="Active" level="3">
+					<ui5-tree-item-custom hide-selection-element type="Active" level="3">
 						<ui5-button slot="content">Level 3</ui5-button>
 					</ui5-tree-item-custom>
 				</ui5-tree-item-custom>

--- a/apps/playground/src/app/app.component.html
+++ b/apps/playground/src/app/app.component.html
@@ -3,19 +3,19 @@
 
 <h3>Radio</h3>
 <section>
-  <button (click)="updateRadioFormModel()">radioControl.setValue("Option 1")</button>FormControl value: {{ radioControl.value }}, touched: {{ radioControl.touched }}<br>
+  <ui5-button (click)="updateRadioFormModel()">radioControl.setValue("Option 1")</ui5-button>FormControl value: {{ radioControl.value }}, touched: {{ radioControl.touched }}<br>
 
   <ui5-radio-button name="GroupA" text="Option 1" [value]="'Option 1'" [formControl]="radioControl"></ui5-radio-button>
-  <ui5-radio-button name="GroupA" text="Option 2" value="Option 2" [formControl]="radioControl" [checked]="true"></ui5-radio-button>
+  <ui5-radio-button name="GroupA" text="Option 2" value="Option 2" [formControl]="radioControl" checked></ui5-radio-button>
   <ui5-radio-button name="GroupA" text="Option 3" value="Option 3" [formControl]="radioControl"></ui5-radio-button>
 </section>
 
 
 <h3>Select</h3>
 <section>
-  <button (click)="updateSelectFormModel()">selectControl.setValue("phone")</button> FormControl value: {{ selectControl.value }}, touched: {{ selectControl.touched }}<br>
+  <ui5-button (click)="updateSelectFormModel()">selectControl.setValue("phone")</ui5-button> FormControl value: {{ selectControl.value }}, touched: {{ selectControl.touched }}<br>
 
-  <ui5-select class="select" [formControl]="selectControl" formControlName="sel">
+  <ui5-select class="select" [formControl]="selectControl">
     <ui5-option value="phone">Phone</ui5-option>
     <ui5-option value="tablet">Tablet</ui5-option>
     <ui5-option value="desktop">Desktop</ui5-option>
@@ -25,7 +25,7 @@
 
 <h3>CheckBox</h3>
 <section>
-	<button (click)="updateCbFormModel()">cbControl.setValue(true)</button>FormControl value: {{ cbControl.value }}, touched: {{ cbControl.touched }}<br>
+	<ui5-button (click)="updateCbFormModel()">cbControl.setValue(true)</ui5-button>FormControl value: {{ cbControl.value }}, touched: {{ cbControl.touched }}<br>
 
 	<ui5-checkbox [formControl]="cbControl"></ui5-checkbox>
 </section>
@@ -33,29 +33,29 @@
 
 <h3>Input</h3>
 <section>
-  <button (click)="updateInpFormModel()">inpControl.setValue("form updated")</button> FormControl value: {{ inpControl.value }}, touched: {{ inpControl.touched }}<br>
+  <ui5-button (click)="updateInpFormModel()">inpControl.setValue("form updated")</ui5-button> FormControl value: {{ inpControl.value }}, touched: {{ inpControl.touched }}<br>
 
   <ui5-input [formControl]="inpControl"></ui5-input>
 </section>
 
 <h3>DatePicker</h3>
 <section>
-  <button (click)="updateDPFormModel()">dpControl.setValue("29 мая 2024 г.")</button> FormControl value: {{ dpControl.value }}, touched: {{ dpControl.touched }}<br>
+  <ui5-button (click)="updateDPFormModel()">dpControl.setValue("29 мая 2024 г.")</ui5-button> FormControl value: {{ dpControl.value }}, touched: {{ dpControl.touched }}<br>
 
   <ui5-date-picker [formControl]="dpControl"></ui5-date-picker>
 </section>
 
 
 <h2>Profile Form</h2>
-<p><ui5-label [showColon]="true">Name</ui5-label> <ui5-text>{{ profileForm.value.name || "N/A"}}</ui5-text> </p>
-<p><ui5-label [showColon]="true">Email</ui5-label> <ui5-text>{{ profileForm.value.email || "N/A"}}</ui5-text></p>
+<p><ui5-label show-colon>Name</ui5-label> <ui5-text>{{ profileForm.value.name || "N/A"}}</ui5-text> </p>
+<p><ui5-label showColon>Email</ui5-label> <ui5-text>{{ profileForm.value.email || "N/A"}}</ui5-text></p>
 
 <form [formGroup]="profileForm"  (ngSubmit)="handleSubmit()">
 
-  <ui5-label for="nameInp" [showColon]="true">Name</ui5-label>
+  <ui5-label for="nameInp" show-colon>Name</ui5-label>
   <ui5-input id="nameInp" formControlName="name"></ui5-input>
 
-  <ui5-label for="emailInp" [showColon]="true">Email</ui5-label>
+  <ui5-label for="emailInp" show-colon>Email</ui5-label>
   <ui5-input formControlName="email"></ui5-input>
 
   <ui5-button type="Submit" [disabled]="!profileForm.valid">Submit</ui5-button>

--- a/libs/angular-generator/src/lib/ui5-webcomponents/component-file.ts
+++ b/libs/angular-generator/src/lib/ui5-webcomponents/component-file.ts
@@ -40,7 +40,7 @@ export class ComponentFile extends AngularGeneratedFile {
       exported: this.componentClassName,
       types: [ExportSpecifierType.Class, AngularExportSpecifierType.NgModule]
     })
-    this.addImport(['Component', 'ElementRef', 'NgZone', 'ChangeDetectorRef', 'inject'], '@angular/core');
+    this.addImport(['Component', 'ElementRef', 'NgZone', 'ChangeDetectorRef', 'booleanAttribute', 'Input as InputDecorator', 'inject'], '@angular/core');
     if (this.componentData.outputs.length) {
       this.addImport(['EventEmitter'], '@angular/core');
       this.addImport(['ProxyOutputs'], utilsFile.relativePathFrom);
@@ -102,11 +102,20 @@ export class ComponentFile extends AngularGeneratedFile {
   }
 
   get inputsCode(): string {
-    return this.componentData.inputs.map(i => `
-    /**
-     ${i.description}
-    */
-    ${i.name}${i.defaultValue ? '!' : '?'}: ${i.type}`).join(';\n');
+    return this.componentData.inputs.map(i => {
+      let decoratorExpr = "";
+
+      if (i.type === "boolean") {
+        decoratorExpr = `@InputDecorator({ transform: booleanAttribute })\n`;
+      }
+
+      return `
+        /**
+        ${i.description}
+        */
+        ${decoratorExpr} ${i.name}!: ${i.type};
+      `
+    }).join(';\n');
   }
 
   set cvaGetterCode(val: string) {

--- a/libs/ui5-angular/__snapshots__/fiori-snapshot-test.spec.ts.snap
+++ b/libs/ui5-angular/__snapshots__/fiori-snapshot-test.spec.ts.snap
@@ -6,7 +6,9 @@ exports[`Snapshot test Fiori Barcode Scanner Dialog should match the snapshot 1`
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/BarcodeScannerDialog.js';
@@ -32,8 +34,9 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class BarcodeScannerDialogComponent {
   /**
-     Indicates whether the dialog is open.
-    */
+        Indicates whether the dialog is open.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
 
   /**
@@ -139,7 +142,9 @@ exports[`Snapshot test Fiori Dynamic Page should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/DynamicPage.js';
@@ -160,23 +165,24 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class DynamicPageComponent {
   /**
-     Defines if the pin button is hidden.
-    */
+        Defines if the pin button is hidden.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hidePinButton!: boolean;
-
   /**
-     Defines if the header is pinned.
-    */
+        Defines if the header is pinned.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   headerPinned!: boolean;
-
   /**
-     Defines if the footer is shown.
-    */
+        Defines if the footer is shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showFooter!: boolean;
-
   /**
-     Defines if the header is snapped.
-    */
+        Defines if the header is snapped.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   headerSnapped!: boolean;
 
   /**
@@ -210,7 +216,9 @@ exports[`Snapshot test Fiori Dynamic Side Content should match the snapshot 1`] 
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/DynamicSideContent.js';
@@ -245,42 +253,40 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class DynamicSideContentComponent {
   /**
-     Defines the visibility of the main content.
-    */
+        Defines the visibility of the main content.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideMainContent!: boolean;
-
   /**
-     Defines the visibility of the side content.
-    */
+        Defines the visibility of the side content.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideSideContent!: boolean;
-
   /**
-     Defines whether the side content is positioned before the main content (left side
+        Defines whether the side content is positioned before the main content (left side
 in LTR mode), or after the the main content (right side in LTR mode).
-    */
+        */
   sideContentPosition!: 'End' | 'Start';
-
   /**
-     Defines on which breakpoints the side content is visible.
-    */
+        Defines on which breakpoints the side content is visible.
+        */
   sideContentVisibility!:
     | 'AlwaysShow'
     | 'ShowAboveL'
     | 'ShowAboveM'
     | 'ShowAboveS'
     | 'NeverShow';
-
   /**
-     Defines on which breakpoints the side content falls down below the main content.
-    */
+        Defines on which breakpoints the side content falls down below the main content.
+        */
   sideContentFallDown!: 'BelowXL' | 'BelowL' | 'BelowM' | 'OnMinimumWidth';
-
   /**
-     Defines whether the component is in equal split mode. In this mode, the side and
+        Defines whether the component is in equal split mode. In this mode, the side and
 the main content take 50:50 percent of the container on all screen sizes
 except for phone, where the main and side contents are switching visibility
 using the toggle method.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   equalSplit!: boolean;
 
   /**
@@ -309,7 +315,9 @@ exports[`Snapshot test Fiori Filter Item Option should match the snapshot 1`] = 
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/FilterItemOption.js';
@@ -325,13 +333,13 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class FilterItemOptionComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines if the component is selected.
-    */
+        Defines if the component is selected.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<FilterItemOption> = inject(ElementRef);
@@ -371,13 +379,12 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class FilterItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the additional text of the component.
-    */
+        Defines the additional text of the component.
+        */
   additionalText!: string;
 
   private elementRef: ElementRef<FilterItem> = inject(ElementRef);
@@ -402,7 +409,9 @@ exports[`Snapshot test Fiori Flexible Column Layout should match the snapshot 1`
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/FlexibleColumnLayout.js';
@@ -424,14 +433,14 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class FlexibleColumnLayoutComponent {
   /**
-     Defines the columns layout and their proportion.
+        Defines the columns layout and their proportion.
 
 **Note:** The layout also depends on the screen size - one column for screens smaller than 599px,
 two columns between 599px and 1023px and three columns for sizes bigger than 1023px.
 
 **For example:** layout=\`TwoColumnsStartExpanded\` means the layout will display up to two columns
 in 67%/33% proportion.
-    */
+        */
   layout!:
     | 'OneColumn'
     | 'TwoColumnsStartExpanded'
@@ -442,15 +451,14 @@ in 67%/33% proportion.
     | 'ThreeColumnsMidExpandedEndHidden'
     | 'MidColumnFullScreen'
     | 'EndColumnFullScreen';
-
   /**
-     Defines the visibility of the arrows,
+        Defines the visibility of the arrows,
 used for expanding and shrinking the columns.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideArrows!: boolean;
-
   /**
-     Defines additional accessibility attributes on different areas of the component.
+        Defines additional accessibility attributes on different areas of the component.
 
 The accessibilityAttributes object has the following fields,
 where each field is an object supporting one or more accessibility attributes:
@@ -472,7 +480,7 @@ Accepts the following values: \`none\`, \`complementary\`, \`contentinfo\`, \`ma
 
 - **name**: Defines the accessible ARIA name of the area.
 Accepts any string.
-    */
+        */
   accessibilityAttributes!: FCLAccessibilityAttributes;
 
   /**
@@ -524,7 +532,7 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class IllustratedMessageComponent {
   /**
-     Defines the illustration name that will be displayed in the component.
+        Defines the illustration name that will be displayed in the component.
 
 Example:
 
@@ -545,36 +553,32 @@ When using an illustration type, other than the default, it should be loaded in 
 For TNT illustrations:
 
 \`import \\"@ui5/webcomponents-fiori/dist/illustrations/tnt/SessionExpired.js\\";\`
-    */
+        */
   name!: string;
-
   /**
-     Determines which illustration breakpoint variant is used.
+        Determines which illustration breakpoint variant is used.
 
 As \`IllustratedMessage\` adapts itself around the \`Illustration\`, the other
 elements of the component are displayed differently on the different breakpoints/illustration designs.
-    */
+        */
   design!: 'Auto' | 'Base' | 'Dot' | 'Spot' | 'Dialog' | 'Scene';
-
   /**
-     Defines the subtitle of the component.
+        Defines the subtitle of the component.
 
 **Note:** Using this property, the default subtitle text of illustration will be overwritten.
 
 **Note:** Using \`subtitle\` slot, the default of this property will be overwritten.
-    */
+        */
   subtitleText!: string;
-
   /**
-     Defines the title of the component.
+        Defines the title of the component.
 
 **Note:** Using this property, the default title text of illustration will be overwritten.
-    */
+        */
   titleText!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   private elementRef: ElementRef<IllustratedMessage> = inject(ElementRef);
@@ -600,7 +604,9 @@ exports[`Snapshot test Fiori Media Gallery Item should match the snapshot 1`] = 
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/MediaGalleryItem.js';
@@ -616,18 +622,18 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class MediaGalleryItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines whether the component is in disabled state.
-    */
+        Defines whether the component is in disabled state.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines the layout of the item container.
-    */
+        Determines the layout of the item container.
+        */
   layout!: 'Square' | 'Wide';
 
   private elementRef: ElementRef<MediaGalleryItem> = inject(ElementRef);
@@ -652,7 +658,9 @@ exports[`Snapshot test Fiori Media Gallery should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/MediaGallery.js';
@@ -689,36 +697,34 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class MediaGalleryComponent {
   /**
-     If set to \`true\`, all thumbnails are rendered in a scrollable container.
+        If set to \`true\`, all thumbnails are rendered in a scrollable container.
 If \`false\`, only up to five thumbnails are rendered, followed by
 an overflow button that shows the count of the remaining thumbnails.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showAllThumbnails!: boolean;
-
   /**
-     If enabled, a \`display-area-click\` event is fired
+        If enabled, a \`display-area-click\` event is fired
 when the user clicks or taps on the display area.
 
 The display area is the central area that contains
 the enlarged content of the currently selected item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   interactiveDisplayArea!: boolean;
-
   /**
-     Determines the layout of the component.
-    */
+        Determines the layout of the component.
+        */
   layout!: 'Auto' | 'Vertical' | 'Horizontal';
-
   /**
-     Determines the horizontal alignment of the thumbnails menu
+        Determines the horizontal alignment of the thumbnails menu
 vs. the central display area.
-    */
+        */
   menuHorizontalAlign!: 'Left' | 'Right';
-
   /**
-     Determines the vertical alignment of the thumbnails menu
+        Determines the vertical alignment of the thumbnails menu
 vs. the central display area.
-    */
+        */
   menuVerticalAlign!: 'Top' | 'Bottom';
 
   /**
@@ -760,7 +766,9 @@ exports[`Snapshot test Fiori Notification List Group Item should match the snaps
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/NotificationListGroupItem.js';
@@ -792,36 +800,35 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class NotificationListGroupItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the \`titleText\` of the item.
-    */
+        Defines the \`titleText\` of the item.
+        */
   titleText!: string;
-
   /**
-     Defines if the \`notification\` is new or has been already read.
+        Defines if the \`notification\` is new or has been already read.
 
 **Note:** if set to \`false\` the \`titleText\` has bold font,
 if set to true - it has a normal font.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   read!: boolean;
-
   /**
-     Defines if a busy indicator would be displayed over the item.
-    */
+        Defines if a busy indicator would be displayed over the item.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the busy indicator will show up for this component.
-    */
+        Defines the delay in milliseconds, after which the busy indicator will show up for this component.
+        */
   loadingDelay!: number;
-
   /**
-     Defines if the group is collapsed or expanded.
-    */
+        Defines if the group is collapsed or expanded.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   collapsed!: boolean;
 
   /**
@@ -852,7 +859,9 @@ exports[`Snapshot test Fiori Notification List Item should match the snapshot 1`
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/NotificationListItem.js';
@@ -893,55 +902,51 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class NotificationListItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the \`titleText\` of the item.
-    */
+        Defines the \`titleText\` of the item.
+        */
   titleText!: string;
-
   /**
-     Defines if the \`notification\` is new or has been already read.
+        Defines if the \`notification\` is new or has been already read.
 
 **Note:** if set to \`false\` the \`titleText\` has bold font,
 if set to true - it has a normal font.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   read!: boolean;
-
   /**
-     Defines if a busy indicator would be displayed over the item.
-    */
+        Defines if a busy indicator would be displayed over the item.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the busy indicator will show up for this component.
-    */
+        Defines the delay in milliseconds, after which the busy indicator will show up for this component.
+        */
   loadingDelay!: number;
-
   /**
-     Defines if the \`titleText\` and \`description\` should wrap,
+        Defines if the \`titleText\` and \`description\` should wrap,
 they truncate by default.
 
 **Note:** by default the \`titleText\` and \`description\`,
 and a \`ShowMore/Less\` button would be displayed.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Defines the status indicator of the item.
-    */
+        Defines the status indicator of the item.
+        */
   state!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines if the \`Close\` button would be displayed.
-    */
+        Defines if the \`Close\` button would be displayed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showClose!: boolean;
-
   /**
-     Defines the \`Important\` label of the item.
-    */
+        Defines the \`Important\` label of the item.
+        */
   importance!: 'Standard' | 'Important';
 
   /**
@@ -998,8 +1003,8 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class NotificationListComponent {
   /**
-     Defines the text that is displayed when the component contains no items.
-    */
+        Defines the text that is displayed when the component contains no items.
+        */
   noDataText!: string;
 
   /**
@@ -1036,7 +1041,9 @@ exports[`Snapshot test Fiori Page should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/Page.js';
@@ -1052,28 +1059,28 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class PageComponent {
   /**
-     Defines the background color of the \`ui5-page\`.
+        Defines the background color of the \`ui5-page\`.
 
 **Note:** When a ui5-list is placed inside the page, we recommend using “List” to ensure better color contrast.
-    */
+        */
   backgroundDesign!: 'List' | 'Solid' | 'Transparent';
-
   /**
-     Disables vertical scrolling of page content.
+        Disables vertical scrolling of page content.
 If set to true, there will be no vertical scrolling at all.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noScrolling!: boolean;
-
   /**
-     Defines if the footer is fixed at the very bottom of the page.
+        Defines if the footer is fixed at the very bottom of the page.
 
 **Note:** When set to true the footer is fixed at the very bottom of the page, otherwise it floats over the content with a slight offset from the bottom.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   fixedFooter!: boolean;
-
   /**
-     Defines the footer visibility.
-    */
+        Defines the footer visibility.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideFooter!: boolean;
 
   private elementRef: ElementRef<Page> = inject(ElementRef);
@@ -1116,28 +1123,25 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class ProductSwitchItemComponent {
   /**
-     Defines the title of the component.
-    */
+        Defines the title of the component.
+        */
   titleText!: string;
-
   /**
-     Defines the subtitle of the component.
-    */
+        Defines the subtitle of the component.
+        */
   subtitleText!: string;
-
   /**
-     Defines the icon to be displayed as a graphical element within the component.
+        Defines the icon to be displayed as a graphical element within the component.
 
 Example:
 
 \`<ui5-product-switch-item icon=\\"palette\\">\`
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines a target where the \`targetSrc\` content must be open.
+        Defines a target where the \`targetSrc\` content must be open.
 
 Available options are:
 
@@ -1146,12 +1150,11 @@ Available options are:
 - \`_blank\`
 - \`_parent\`
 - \`_search\`
-    */
+        */
   target!: string;
-
   /**
-     Defines the component target URI. Supports standard hyperlink behavior.
-    */
+        Defines the component target URI. Supports standard hyperlink behavior.
+        */
   targetSrc!: string;
 
   /**
@@ -1237,20 +1240,18 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class ShellBarItemComponent {
   /**
-     Defines the name of the item's icon.
-    */
+        Defines the name of the item's icon.
+        */
   icon!: string;
-
   /**
-     Defines the item text.
+        Defines the item text.
  
   **Note:** The text is only displayed inside the overflow popover list view.
-    */
+        */
   text!: string;
-
   /**
-     Defines the count displayed in the top-right corner.
-    */
+        Defines the count displayed in the top-right corner.
+        */
   count!: string;
 
   /**
@@ -1280,7 +1281,9 @@ exports[`Snapshot test Fiori Shell Bar should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/ShellBar.js';
@@ -1337,44 +1340,41 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class ShellBarComponent {
   /**
-     Defines the \`primaryTitle\`.
+        Defines the \`primaryTitle\`.
 
 **Note:** The \`primaryTitle\` would be hidden on S screen size (less than approx. 700px).
-    */
+        */
   primaryTitle!: string;
-
   /**
-     Defines the \`secondaryTitle\`.
+        Defines the \`secondaryTitle\`.
 
 **Note:** The \`secondaryTitle\` would be hidden on S and M screen sizes (less than approx. 1300px).
-    */
+        */
   secondaryTitle!: string;
-
   /**
-     Defines the \`notificationsCount\`,
+        Defines the \`notificationsCount\`,
 displayed in the notification icon top-right corner.
-    */
+        */
   notificationsCount!: string;
-
   /**
-     Defines, if the notification icon would be displayed.
-    */
+        Defines, if the notification icon would be displayed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showNotifications!: boolean;
-
   /**
-     Defines, if the product switch icon would be displayed.
-    */
+        Defines, if the product switch icon would be displayed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showProductSwitch!: boolean;
-
   /**
-     Defines, if the Search Field would be displayed when there is a valid \`searchField\` slot.
+        Defines, if the Search Field would be displayed when there is a valid \`searchField\` slot.
 
 **Note:** By default the Search Field is not displayed.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showSearchField!: boolean;
-
   /**
-     Defines additional accessibility attributes on different areas of the component.
+        Defines additional accessibility attributes on different areas of the component.
 
 The accessibilityAttributes object has the following fields,
 where each field is an object supporting one or more accessibility attributes:
@@ -1401,7 +1401,7 @@ such as menu or dialog, that can be triggered by the button.
 Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\` or \`tree\`.
 - **name**: Defines the accessible ARIA name of the area.
 Accepts any string.
-    */
+        */
   accessibilityAttributes!: ShellBarAccessibilityAttributes;
 
   /**
@@ -1456,7 +1456,9 @@ exports[`Snapshot test Fiori Side Navigation Group should match the snapshot 1`]
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/SideNavigationGroup.js';
@@ -1472,27 +1474,26 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class SideNavigationGroupComponent {
   /**
-     Defines the text of the item.
-    */
+        Defines the text of the item.
+        */
   text!: string;
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be pressed or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 A tooltip attribute should be provided, in order to represent meaning/function, when the component is collapsed(icon only is visualized).
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines if the item is expanded
-    */
+        Defines if the item is expanded
+        */
+  @InputDecorator({ transform: booleanAttribute })
   expanded!: boolean;
 
   private elementRef: ElementRef<SideNavigationGroup> = inject(ElementRef);
@@ -1517,7 +1518,9 @@ exports[`Snapshot test Fiori Side Navigation Item should match the snapshot 1`] 
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/SideNavigationItem.js';
@@ -1549,29 +1552,27 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class SideNavigationItemComponent {
   /**
-     Defines the icon of the item.
+        Defines the icon of the item.
 
 The SAP-icons font provides numerous options.
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether the item is selected
-    */
+        Defines whether the item is selected
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the link target URI. Supports standard hyperlink behavior.
+        Defines the link target URI. Supports standard hyperlink behavior.
 If a JavaScript action should be triggered,
 this should not be set, but instead an event handler
 for the \`click\` event should be registered.
-    */
+        */
   href!: string;
-
   /**
-     Defines the component target.
+        Defines the component target.
 
 **Notes:**
 
@@ -1582,19 +1583,19 @@ for the \`click\` event should be registered.
 - \`_search\`
 
 **This property must only be used when the \`href\` property is set.**
-    */
+        */
   target!: string;
-
   /**
-     Defines if the item is expanded
-    */
+        Defines if the item is expanded
+        */
+  @InputDecorator({ transform: booleanAttribute })
   expanded!: boolean;
-
   /**
-     Defines whether clicking the whole item or only pressing the icon will show/hide the sub items (if present).
+        Defines whether clicking the whole item or only pressing the icon will show/hide the sub items (if present).
 If set to true, clicking the whole item will toggle the sub items, and it won't fire the \`click\` event.
 By default, only clicking the arrow icon will toggle the sub items.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   wholeItemToggleable!: boolean;
 
   /**
@@ -1625,7 +1626,9 @@ exports[`Snapshot test Fiori Side Navigation Sub Item should match the snapshot 
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/SideNavigationSubItem.js';
@@ -1643,29 +1646,27 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class SideNavigationSubItemComponent {
   /**
-     Defines the icon of the item.
+        Defines the icon of the item.
 
 The SAP-icons font provides numerous options.
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether the item is selected
-    */
+        Defines whether the item is selected
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the link target URI. Supports standard hyperlink behavior.
+        Defines the link target URI. Supports standard hyperlink behavior.
 If a JavaScript action should be triggered,
 this should not be set, but instead an event handler
 for the \`click\` event should be registered.
-    */
+        */
   href!: string;
-
   /**
-     Defines the component target.
+        Defines the component target.
 
 **Notes:**
 
@@ -1676,7 +1677,7 @@ for the \`click\` event should be registered.
 - \`_search\`
 
 **This property must only be used when the \`href\` property is set.**
-    */
+        */
   target!: string;
 
   /**
@@ -1707,7 +1708,9 @@ exports[`Snapshot test Fiori Side Navigation should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/SideNavigation.js';
@@ -1728,8 +1731,9 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class SideNavigationComponent {
   /**
-     Defines whether the \`ui5-side-navigation\` is expanded or collapsed.
-    */
+        Defines whether the \`ui5-side-navigation\` is expanded or collapsed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   collapsed!: boolean;
 
   /**
@@ -1758,7 +1762,9 @@ exports[`Snapshot test Fiori Sort Item should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/SortItem.js';
@@ -1774,13 +1780,13 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class SortItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines if the component is selected.
-    */
+        Defines if the component is selected.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<SortItem> = inject(ElementRef);
@@ -1826,7 +1832,9 @@ exports[`Snapshot test Fiori Timeline Item should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/TimelineItem.js';
@@ -1844,31 +1852,28 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class TimelineItemComponent {
   /**
-     Defines the icon to be displayed as graphical element within the \`ui5-timeline-item\`.
+        Defines the icon to be displayed as graphical element within the \`ui5-timeline-item\`.
 SAP-icons font provides numerous options.
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the name of the item, displayed before the \`title-text\`.
-    */
+        Defines the name of the item, displayed before the \`title-text\`.
+        */
   name!: string;
-
   /**
-     Defines if the \`name\` is clickable.
-    */
+        Defines if the \`name\` is clickable.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   nameClickable!: boolean;
-
   /**
-     Defines the title text of the component.
-    */
+        Defines the title text of the component.
+        */
   titleText!: string;
-
   /**
-     Defines the subtitle text of the component.
-    */
+        Defines the subtitle text of the component.
+        */
   subtitleText!: string;
 
   /**
@@ -1917,13 +1922,12 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class TimelineComponent {
   /**
-     Defines the items orientation.
-    */
+        Defines the items orientation.
+        */
   layout!: 'Vertical' | 'Horizontal';
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
 
   private elementRef: ElementRef<Timeline> = inject(ElementRef);
@@ -2032,7 +2036,9 @@ exports[`Snapshot test Fiori Upload Collection Item should match the snapshot 1`
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/UploadCollectionItem.js';
@@ -2095,21 +2101,20 @@ import { ListItemAccessibilityAttributes } from '@ui5/webcomponents/dist/ListIte
 })
 class UploadCollectionItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -2117,70 +2122,64 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Holds an instance of \`File\` associated with this item.
-    */
+        Holds an instance of \`File\` associated with this item.
+        */
   file!: File | null | undefined;
-
   /**
-     The name of the file.
-    */
+        The name of the file.
+        */
   fileName!: string;
-
   /**
-     If set to \`true\` the file name will be clickable and it will fire \`file-name-click\` event upon click.
-    */
+        If set to \`true\` the file name will be clickable and it will fire \`file-name-click\` event upon click.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   fileNameClickable!: boolean;
-
   /**
-     Disables the delete button.
-    */
+        Disables the delete button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disableDeleteButton!: boolean;
-
   /**
-     Hides the delete button.
-    */
+        Hides the delete button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideDeleteButton!: boolean;
-
   /**
-     Hides the retry button when \`uploadState\` property is \`Error\`.
-    */
+        Hides the retry button when \`uploadState\` property is \`Error\`.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideRetryButton!: boolean;
-
   /**
-     Hides the terminate button when \`uploadState\` property is \`Uploading\`.
-    */
+        Hides the terminate button when \`uploadState\` property is \`Uploading\`.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideTerminateButton!: boolean;
-
   /**
-     The upload progress in percentage.
+        The upload progress in percentage.
 
 **Note:** Expected values are in the interval [0, 100].
-    */
+        */
   progress!: number;
-
   /**
-     Upload state.
+        Upload state.
 
 Depending on this property, the item displays the following:
 
@@ -2188,7 +2187,7 @@ Depending on this property, the item displays the following:
 - \`Uploading\` - progress indicator and terminate button are displayed. When the terminate button is pressed, \`terminate\` event is fired.
 - \`Error\` - progress indicator and retry button are displayed. When the retry button is pressed, \`retry\` event is fired.
 - \`Complete\` - progress indicator is not displayed.
-    */
+        */
   uploadState!: 'Complete' | 'Error' | 'Ready' | 'Uploading';
 
   /**
@@ -2243,7 +2242,9 @@ exports[`Snapshot test Fiori Upload Collection should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/UploadCollection.js';
@@ -2281,8 +2282,8 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class UploadCollectionComponent {
   /**
-     Defines the selection mode of the \`ui5-upload-collection\`.
-    */
+        Defines the selection mode of the \`ui5-upload-collection\`.
+        */
   selectionMode!:
     | 'None'
     | 'Single'
@@ -2290,29 +2291,26 @@ class UploadCollectionComponent {
     | 'SingleEnd'
     | 'SingleAuto'
     | 'Multiple';
-
   /**
-     Allows you to set your own text for the 'No data' description.
-    */
+        Allows you to set your own text for the 'No data' description.
+        */
   noDataDescription!: string;
-
   /**
-     Allows you to set your own text for the 'No data' text.
-    */
+        Allows you to set your own text for the 'No data' text.
+        */
   noDataText!: string;
-
   /**
-     By default there will be drag and drop overlay shown over the \`ui5-upload-collection\` when files
+        By default there will be drag and drop overlay shown over the \`ui5-upload-collection\` when files
 are dragged. If you don't intend to use drag and drop, set this property.
 
 **Note:** It is up to the application developer to add handler for \`drop\` event and handle it.
 \`ui5-upload-collection\` only displays an overlay.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideDragOverlay!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
 
   /**
@@ -2353,7 +2351,9 @@ exports[`Snapshot test Fiori View Settings Dialog should match the snapshot 1`] 
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/ViewSettingsDialog.js';
@@ -2379,8 +2379,9 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class ViewSettingsDialogComponent {
   /**
-     Defines the initial sort order.
-    */
+        Defines the initial sort order.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   sortDescending!: boolean;
 
   /**
@@ -2417,7 +2418,9 @@ exports[`Snapshot test Fiori Wizard Step should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import '@ui5/webcomponents-fiori/dist/WizardStep.js';
@@ -2447,53 +2450,51 @@ import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
 })
 class WizardStepComponent {
   /**
-     Defines the \`titleText\` of the step.
+        Defines the \`titleText\` of the step.
 
 **Note:** The text is displayed in the \`ui5-wizard\` navigation header.
-    */
+        */
   titleText!: string;
-
   /**
-     Defines the \`subtitleText\` of the step.
+        Defines the \`subtitleText\` of the step.
 
 **Note:** the text is displayed in the \`ui5-wizard\` navigation header.
-    */
+        */
   subtitleText!: string;
-
   /**
-     Defines the \`icon\` of the step.
+        Defines the \`icon\` of the step.
 
 **Note:** The icon is displayed in the \`ui5-wizard\` navigation header.
 
 The SAP-icons font provides numerous options.
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines if the step is \`disabled\`. When disabled the step is displayed,
+        Defines if the step is \`disabled\`. When disabled the step is displayed,
 but the user can't select the step by clicking or navigate to it with scrolling.
 
 **Note:** Step can't be \`selected\` and \`disabled\` at the same time.
 In this case the \`selected\` property would take precedence.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the step's \`selected\` state - the step that is currently active.
+        Defines the step's \`selected\` state - the step that is currently active.
 
 **Note:** Step can't be \`selected\` and \`disabled\` at the same time.
 In this case the \`selected\` property would take precedence.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     When \`branching\` is enabled a dashed line would be displayed after the step,
+        When \`branching\` is enabled a dashed line would be displayed after the step,
 meant to indicate that the next step is not yet known and depends on user choice in the current step.
 
 **Note:** It is recommended to use \`branching\` on the last known step
 and later add new steps when it becomes clear how the wizard flow should continue.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   branching!: boolean;
 
   private elementRef: ElementRef<WizardStep> = inject(ElementRef);
@@ -2539,8 +2540,8 @@ import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
 })
 class WizardComponent {
   /**
-     Defines how the content of the \`ui5-wizard\` would be visualized.
-    */
+        Defines how the content of the \`ui5-wizard\` would be visualized.
+        */
   contentLayout!: 'MultipleSteps' | 'SingleStep';
 
   /**

--- a/libs/ui5-angular/__snapshots__/main-snapshot-test.spec.ts.snap
+++ b/libs/ui5-angular/__snapshots__/main-snapshot-test.spec.ts.snap
@@ -28,17 +28,16 @@ import {
 })
 class AvatarGroupComponent {
   /**
-     Defines the mode of the \`AvatarGroup\`.
-    */
+        Defines the mode of the \`AvatarGroup\`.
+        */
   type!: 'Group' | 'Individual';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following field is supported:
 
 - **hasPopup**: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the button.
 Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\` or \`tree\`.
-    */
+        */
   accessibilityAttributes!: AvatarGroupAccessibilityAttributes;
 
   /**
@@ -73,7 +72,9 @@ exports[`Snapshot test Main Avatar should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -114,22 +115,22 @@ import {
 })
 class AvatarComponent {
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be pressed or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines if the avatar is interactive (focusable and pressable).
+        Defines if the avatar is interactive (focusable and pressable).
 
 **Note:** This property won't have effect if the \`disabled\`
 property is set to \`true\`.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   interactive!: boolean;
-
   /**
-     Defines the name of the UI5 Icon, that will be displayed.
+        Defines the name of the UI5 Icon, that will be displayed.
 
 **Note:** If \`image\` slot is provided, the property will be ignored.
 
@@ -142,11 +143,10 @@ property is set to \`true\`.
 **Note:** If no icon or an empty one is provided, by default the \\"employee\\" icon should be displayed.
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the name of the fallback icon, which should be displayed in the following cases:
+        Defines the name of the fallback icon, which should be displayed in the following cases:
 
 	- If the initials are not valid (more than 3 letters, unsupported languages or empty initials).
 	- If there are three initials and they do not fit in the shape (e.g. WWW for some of the sizes).
@@ -161,29 +161,25 @@ See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-
 \`<ui5-avatar fallback-icon=\\"alert\\">\`
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   fallbackIcon!: string;
-
   /**
-     Defines the displayed initials.
+        Defines the displayed initials.
 
 Up to three Latin letters can be displayed as initials.
-    */
+        */
   initials!: string;
-
   /**
-     Defines the shape of the component.
-    */
+        Defines the shape of the component.
+        */
   shape!: 'Circle' | 'Square';
-
   /**
-     Defines predefined size of the component.
-    */
+        Defines predefined size of the component.
+        */
   size!: 'XS' | 'S' | 'M' | 'L' | 'XL';
-
   /**
-     Defines the background color of the desired image.
-    */
+        Defines the background color of the desired image.
+        */
   colorScheme!:
     | 'Accent1'
     | 'Accent2'
@@ -196,20 +192,18 @@ Up to three Latin letters can be displayed as initials.
     | 'Accent9'
     | 'Accent10'
     | 'Placeholder';
-
   /**
-     Defines the text alternative of the component.
+        Defines the text alternative of the component.
 If not provided a default text alternative will be set, if present.
-    */
+        */
   accessibleName!: string;
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following field is supported:
 
 - **hasPopup**: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the button.
 Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\` or \`tree\`.
-    */
+        */
   accessibilityAttributes!: AvatarAccessibilityAttributes;
 
   private elementRef: ElementRef<Avatar> = inject(ElementRef);
@@ -249,8 +243,8 @@ import Bar from '@ui5/webcomponents/dist/Bar.js';
 })
 class BarComponent {
   /**
-     Defines the component's design.
-    */
+        Defines the component's design.
+        */
   design!: 'Header' | 'Subheader' | 'Footer' | 'FloatingFooter';
 
   private elementRef: ElementRef<Bar> = inject(ElementRef);
@@ -290,14 +284,13 @@ import BreadcrumbsItem from '@ui5/webcomponents/dist/BreadcrumbsItem.js';
 })
 class BreadcrumbsItemComponent {
   /**
-     Defines the link href.
+        Defines the link href.
 
 **Note:** Standard hyperlink behavior is supported.
-    */
+        */
   href!: string;
-
   /**
-     Defines the link target.
+        Defines the link target.
 
 Available options are:
 
@@ -308,12 +301,11 @@ Available options are:
 - \`_search\`
 
 **Note:** This property must only be used when the \`href\` property is set.
-    */
+        */
   target!: string | undefined;
-
   /**
-     Defines the accessible ARIA name of the item.
-    */
+        Defines the accessible ARIA name of the item.
+        */
   accessibleName!: string;
 
   private elementRef: ElementRef<BreadcrumbsItem> = inject(ElementRef);
@@ -359,17 +351,16 @@ import {
 })
 class BreadcrumbsComponent {
   /**
-     Defines the visual appearance of the last BreadcrumbsItem.
+        Defines the visual appearance of the last BreadcrumbsItem.
 
 The Breadcrumbs supports two visual appearances for the last BreadcrumbsItem:
 - \\"Standard\\" - displaying the last item as \\"current page\\" (bold and without separator)
 - \\"NoCurrentPage\\" - displaying the last item as a regular BreadcrumbsItem, followed by separator
-    */
+        */
   design!: 'Standard' | 'NoCurrentPage';
-
   /**
-     Determines the visual style of the separator between the breadcrumb items.
-    */
+        Determines the visual style of the separator between the breadcrumb items.
+        */
   separators!:
     | 'Slash'
     | 'BackSlash'
@@ -406,7 +397,9 @@ exports[`Snapshot test Main Busy Indicator should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -422,28 +415,25 @@ import BusyIndicator from '@ui5/webcomponents/dist/BusyIndicator.js';
 })
 class BusyIndicatorComponent {
   /**
-     Defines text to be displayed below the component. It can be used to inform the user of the current operation.
-    */
+        Defines text to be displayed below the component. It can be used to inform the user of the current operation.
+        */
   text!: string;
-
   /**
-     Defines the size of the component.
-    */
+        Defines the size of the component.
+        */
   size!: 'S' | 'M' | 'L';
-
   /**
-     Defines if the busy indicator is visible on the screen. By default it is not.
-    */
+        Defines if the busy indicator is visible on the screen. By default it is not.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   active!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the busy indicator will be visible on the screen.
-    */
+        Defines the delay in milliseconds, after which the busy indicator will be visible on the screen.
+        */
   delay!: number;
-
   /**
-     Defines the placement of the text.
-    */
+        Defines the placement of the text.
+        */
   textPlacement!: 'Top' | 'Bottom';
 
   private elementRef: ElementRef<BusyIndicator> = inject(ElementRef);
@@ -468,7 +458,9 @@ exports[`Snapshot test Main Button should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -513,8 +505,8 @@ import {
 })
 class ButtonComponent {
   /**
-     Defines the component design.
-    */
+        Defines the component design.
+        */
   design!:
     | 'Default'
     | 'Positive'
@@ -522,25 +514,23 @@ class ButtonComponent {
     | 'Transparent'
     | 'Emphasized'
     | 'Attention';
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be pressed or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the icon, displayed as graphical element within the component.
+        Defines the icon, displayed as graphical element within the component.
 The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the icon, displayed as graphical element within the component after the button text.
+        Defines the icon, displayed as graphical element within the component after the button text.
 
 **Note:** It is highly recommended to use \`endIcon\` property only together with \`icon\` and/or \`text\` properties.
 Usage of \`endIcon\` only should be avoided.
@@ -549,36 +539,32 @@ The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   endIcon!: string;
-
   /**
-     When set to \`true\`, the component will
+        When set to \`true\`, the component will
 automatically submit the nearest HTML form element on \`press\`.
 
 **Note:** This property is only applicable within the context of an HTML Form element.\`
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   submits!: boolean;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 **Note:** A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **expanded**: Indicates whether the button, or another grouping element it controls, is currently expanded or collapsed.
@@ -589,21 +575,19 @@ Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\`
 
 - **controls**: Identifies the element (or elements) whose contents or presence are controlled by the button element.
 Accepts a lowercase string value.
-    */
+        */
   accessibilityAttributes!: ButtonAccessibilityAttributes;
-
   /**
-     Defines whether the button has special form-related functionality.
+        Defines whether the button has special form-related functionality.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   type!: 'Button' | 'Submit' | 'Reset';
-
   /**
-     Describes the accessibility role of the button.
+        Describes the accessibility role of the button.
 
 **Note:** Use <code>ButtonAccessibleRole.Link</code> role only with a press handler, which performs a navigation. In all other scenarios the default button semantics are recommended.
-    */
+        */
   accessibleRole!: 'Button' | 'Link';
 
   /**
@@ -652,15 +636,14 @@ import CalendarDateRange from '@ui5/webcomponents/dist/CalendarDateRange.js';
 })
 class CalendarDateRangeComponent {
   /**
-     Start of date range formatted according to the \`formatPattern\` property
+        Start of date range formatted according to the \`formatPattern\` property
 of the \`ui5-calendar\` that hosts the component.
-    */
+        */
   startValue!: string;
-
   /**
-     End of date range formatted according to the \`formatPattern\` property
+        End of date range formatted according to the \`formatPattern\` property
 of the \`ui5-calendar\` that hosts the component.
-    */
+        */
   endValue!: string;
 
   private elementRef: ElementRef<CalendarDateRange> = inject(ElementRef);
@@ -700,9 +683,9 @@ import CalendarDate from '@ui5/webcomponents/dist/CalendarDate.js';
 })
 class CalendarDateComponent {
   /**
-     The date formatted according to the \`formatPattern\` property
+        The date formatted according to the \`formatPattern\` property
 of the \`ui5-calendar\` that hosts the component.
-    */
+        */
   value!: string;
 
   private elementRef: ElementRef<CalendarDate> = inject(ElementRef);
@@ -742,13 +725,12 @@ import CalendarLegendItem from '@ui5/webcomponents/dist/CalendarLegendItem.js';
 })
 class CalendarLegendItemComponent {
   /**
-     Defines the text content of the Calendar Legend Item.
-    */
+        Defines the text content of the Calendar Legend Item.
+        */
   text!: string;
-
   /**
-     Defines the type of the Calendar Legend Item.
-    */
+        Defines the type of the Calendar Legend Item.
+        */
   type!:
     | 'None'
     | 'Working'
@@ -795,7 +777,9 @@ exports[`Snapshot test Main Calendar Legend should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -821,23 +805,24 @@ import CalendarLegend from '@ui5/webcomponents/dist/CalendarLegend.js';
 })
 class CalendarLegendComponent {
   /**
-     Hides the Today item in the legend.
-    */
+        Hides the Today item in the legend.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideToday!: boolean;
-
   /**
-     Hides the Selected day item in the legend.
-    */
+        Hides the Selected day item in the legend.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideSelectedDay!: boolean;
-
   /**
-     Hides the Non-Working day item in the legend.
-    */
+        Hides the Non-Working day item in the legend.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideNonWorkingDay!: boolean;
-
   /**
-     Hides the Working day item in the legend.
-    */
+        Hides the Working day item in the legend.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideWorkingDay!: boolean;
 
   private elementRef: ElementRef<CalendarLegend> = inject(ElementRef);
@@ -862,7 +847,9 @@ exports[`Snapshot test Main Calendar should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -899,9 +886,9 @@ import {
 })
 class CalendarComponent {
   /**
-     Sets a calendar type used for display.
+        Sets a calendar type used for display.
 If not set, the calendar type of the global configuration is used.
-    */
+        */
   primaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -909,11 +896,10 @@ If not set, the calendar type of the global configuration is used.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Defines the secondary calendar type.
+        Defines the secondary calendar type.
 If not set, the calendar will only show the primary calendar type.
-    */
+        */
   secondaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -921,42 +907,38 @@ If not set, the calendar will only show the primary calendar type.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Determines the format, displayed in the input field.
-    */
+        Determines the format, displayed in the input field.
+        */
   formatPattern!: string;
-
   /**
-     Determines the minimum date available for selection.
+        Determines the minimum date available for selection.
 
 **Note:** If the formatPattern property is not set, the minDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   minDate!: string;
-
   /**
-     Determines the maximum date available for selection.
+        Determines the maximum date available for selection.
 
 **Note:** If the formatPattern property is not set, the maxDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   maxDate!: string;
-
   /**
-     Defines the type of selection used in the calendar component.
+        Defines the type of selection used in the calendar component.
 Accepted property values are:
 
 - \`CalendarSelectionMode.Single\` - enables a single date selection.(default value)
 - \`CalendarSelectionMode.Range\` - enables selection of a date range.
 - \`CalendarSelectionMode.Multiple\` - enables selection of multiple dates.
-    */
+        */
   selectionMode!: 'Single' | 'Multiple' | 'Range';
-
   /**
-     Defines the visibility of the week numbers column.
+        Defines the visibility of the week numbers column.
 
 **Note:** For calendars other than Gregorian,
 the week numbers are not displayed regardless of what is set.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideWeekNumbers!: boolean;
 
   /**
@@ -989,7 +971,9 @@ exports[`Snapshot test Main Card Header should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -1007,24 +991,22 @@ import CardHeader from '@ui5/webcomponents/dist/CardHeader.js';
 })
 class CardHeaderComponent {
   /**
-     Defines the title text.
-    */
+        Defines the title text.
+        */
   titleText!: string;
-
   /**
-     Defines the subtitle text.
-    */
+        Defines the subtitle text.
+        */
   subtitleText!: string;
-
   /**
-     Defines the additional text.
-    */
+        Defines the additional text.
+        */
   additionalText!: string;
-
   /**
-     Defines if the component would be interactive,
+        Defines if the component would be interactive,
 e.g gets hover effect, gets focus outline and \`click\` event is fired, when pressed.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   interactive!: boolean;
 
   /**
@@ -1071,15 +1053,14 @@ import Card from '@ui5/webcomponents/dist/Card.js';
 })
 class CardComponent {
   /**
-     Defines the accessible name of the component, which is used as the name of the card region and should be unique per card.
+        Defines the accessible name of the component, which is used as the name of the card region and should be unique per card.
 
 **Note:** \`accessibleName\` should be always set, unless \`accessibleNameRef\` is set.
-    */
+        */
   accessibleName!: string;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   private elementRef: ElementRef<Card> = inject(ElementRef);
@@ -1104,7 +1085,9 @@ exports[`Snapshot test Main Carousel should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -1149,22 +1132,20 @@ import {
 })
 class CarouselComponent {
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines the IDs of the elements that label the input.
-    */
+        Defines the IDs of the elements that label the input.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines whether the carousel should loop, i.e show the first page after the last page is reached and vice versa.
-    */
+        Defines whether the carousel should loop, i.e show the first page after the last page is reached and vice versa.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   cyclic!: boolean;
-
   /**
-     Defines the number of items per page depending on the carousel width.
+        Defines the number of items per page depending on the carousel width.
 
 - 'S' for screens smaller than 600 pixels.
 - 'M' for screens greater than or equal to 600 pixels and smaller than 1024 pixels.
@@ -1172,56 +1153,51 @@ class CarouselComponent {
 - 'XL' for screens greater than or equal to 1440 pixels.
 
 One item per page is shown by default.
-    */
+        */
   itemsPerPage!: string;
-
   /**
-     Defines the visibility of the navigation arrows.
+        Defines the visibility of the navigation arrows.
 If set to true the navigation arrows will be hidden.
 
 **Note:** The navigation arrows are never displayed on touch devices.
 In this case, the user can swipe to navigate through the items.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideNavigationArrows!: boolean;
-
   /**
-     Defines the visibility of the page indicator.
+        Defines the visibility of the page indicator.
 If set to true the page indicator will be hidden.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hidePageIndicator!: boolean;
-
   /**
-     Defines the style of the page indicator.
+        Defines the style of the page indicator.
 Available options are:
 
 - \`Default\` - The page indicator will be visualized as dots if there are fewer than 9 pages. If there are more pages, the page indicator will switch to displaying the current page and the total number of pages. (e.g. X of Y)
 - \`Numeric\` - The page indicator will display the current page and the total number of pages. (e.g. X of Y)
-    */
+        */
   pageIndicatorType!: 'Default' | 'Numeric';
-
   /**
-     Defines the carousel's background design.
-    */
+        Defines the carousel's background design.
+        */
   backgroundDesign!: 'Solid' | 'Transparent' | 'Translucent';
-
   /**
-     Defines the page indicator background design.
-    */
+        Defines the page indicator background design.
+        */
   pageIndicatorBackgroundDesign!: 'Solid' | 'Transparent' | 'Translucent';
-
   /**
-     Defines the page indicator border design.
-    */
+        Defines the page indicator border design.
+        */
   pageIndicatorBorderDesign!: 'Solid' | 'None';
-
   /**
-     Defines the position of arrows.
+        Defines the position of arrows.
 
 Available options are:
 
 - \`Content\` - the arrows are placed on the sides of the current page.
 - \`Navigation\` - the arrows are placed on the sides of the page indicator.
-    */
+        */
   arrowsPlacement!: 'Content' | 'Navigation';
 
   /**
@@ -1253,7 +1229,9 @@ exports[`Snapshot test Main Check Box should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -1300,47 +1278,45 @@ import CheckBox from '@ui5/webcomponents/dist/CheckBox.js';
 })
 class CheckBoxComponent {
   /**
-     Receives id(or many ids) of the elements that label the component
-    */
+        Receives id(or many ids) of the elements that label the component
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Determines whether the \`ui5-checkbox\` is in display only state.
+        Determines whether the \`ui5-checkbox\` is in display only state.
 
 When set to \`true\`, the \`ui5-checkbox\` is not interactive, not editable, not focusable
 and not in the tab chain. This setting is used for forms in review mode.
 
 **Note:** When the property \`disabled\` is set to \`true\` this property has no effect.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   displayOnly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines whether the component is displayed as partially checked.
+        Defines whether the component is displayed as partially checked.
 
 **Note:** The indeterminate state can be set only programmatically and can’t be achieved by user
 interaction and the resulting visual state depends on the values of the \`indeterminate\`
@@ -1349,40 +1325,37 @@ and \`checked\` properties:
 -  If the component is checked and indeterminate, it will be displayed as partially checked
 -  If the component is checked and it is not indeterminate, it will be displayed as checked
 -  If the component is not checked, it will be displayed as not checked regardless value of the indeterminate attribute
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   indeterminate!: boolean;
-
   /**
-     Defines if the component is checked.
+        Defines if the component is checked.
 
 **Note:** The property can be changed with user interaction,
 either by cliking/tapping on the component, or by
 pressing the Enter or Space key.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   checked!: boolean;
-
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component text wraps when there is not enough space.
+        Defines whether the component text wraps when there is not enough space.
 
 **Note:** for option \\"Normal\\" the text will wrap and the words will not be broken based on hyphenation.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
 
   /**
@@ -1421,7 +1394,9 @@ exports[`Snapshot test Main Color Palette Item should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -1437,18 +1412,18 @@ import ColorPaletteItem from '@ui5/webcomponents/dist/ColorPaletteItem.js';
 })
 class ColorPaletteItemComponent {
   /**
-     Defines the colour of the component.
+        Defines the colour of the component.
 
 **Note:** The value should be a valid CSS color.
-    */
+        */
   value!: string | undefined;
-
   /**
-     Defines if the component is selected.
+        Defines if the component is selected.
 
 **Note:** Only one item must be selected per <code>ui5-color-palette</code>.
 If more than one item is defined as selected, the last one would be considered as the selected one.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<ColorPaletteItem> = inject(ElementRef);
@@ -1473,7 +1448,9 @@ exports[`Snapshot test Main Color Palette Popover should match the snapshot 1`] 
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -1508,39 +1485,38 @@ import {
 })
 class ColorPalettePopoverComponent {
   /**
-     Defines whether the user can see the last used colors in the bottom of the component
-    */
+        Defines whether the user can see the last used colors in the bottom of the component
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showRecentColors!: boolean;
-
   /**
-     Defines whether the user can choose a custom color from a component.
+        Defines whether the user can choose a custom color from a component.
 
 **Note:** In order to use this property you need to import the following module: \`\\"@ui5/webcomponents/dist/features/ColorPaletteMoreColors.js\\"\`
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showMoreColors!: boolean;
-
   /**
-     Defines whether the user can choose the default color from a button.
-    */
+        Defines whether the user can choose the default color from a button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showDefaultColor!: boolean;
-
   /**
-     Defines the default color of the component.
+        Defines the default color of the component.
 
 **Note:** The default color should be a part of the ColorPalette colors\`
-    */
+        */
   defaultColor!: string | undefined;
-
   /**
-     Defines the open | closed state of the popover.
-    */
+        Defines the open | closed state of the popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the ID or DOM Reference of the element that the popover is shown at.
+        Defines the ID or DOM Reference of the element that the popover is shown at.
 When using this attribute in a declarative way, you must only use the \`id\` (as a string) of the element at which you want to show the popover.
 You can only set the \`opener\` attribute to a DOM Reference when using JavaScript.
-    */
+        */
   opener!: HTMLElement | string | undefined;
 
   /**
@@ -1638,17 +1614,16 @@ import ColorPicker from '@ui5/webcomponents/dist/ColorPicker.js';
 })
 class ColorPickerComponent {
   /**
-     Defines the currently selected color of the component.
+        Defines the currently selected color of the component.
 
 **Note**: use HEX, RGB, RGBA, HSV formats or a CSS color name when modifying this property.
-    */
+        */
   value!: string;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
 
   /**
@@ -1693,8 +1668,8 @@ import ComboBoxItemGroup from '@ui5/webcomponents/dist/ComboBoxItemGroup.js';
 })
 class ComboBoxItemGroupComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
 
   private elementRef: ElementRef<ComboBoxItemGroup> = inject(ElementRef);
@@ -1734,13 +1709,12 @@ import ComboBoxItem from '@ui5/webcomponents/dist/ComboBoxItem.js';
 })
 class ComboBoxItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the additional text of the component.
-    */
+        Defines the additional text of the component.
+        */
   additionalText!: string;
 
   private elementRef: ElementRef<ComboBoxItem> = inject(ElementRef);
@@ -1765,7 +1739,9 @@ exports[`Snapshot test Main Combo Box should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -1824,76 +1800,70 @@ import {
 })
 class ComboBoxComponent {
   /**
-     Defines the value of the component.
-    */
+        Defines the value of the component.
+        */
   value!: string;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines whether the value will be autocompleted to match an item
-    */
+        Defines whether the value will be autocompleted to match an item
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noTypeahead!: boolean;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the
+        Defines a short hint intended to aid the user with data entry when the
 component has no value.
-    */
+        */
   placeholder!: string;
-
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Indicates whether a loading indicator should be shown in the picker.
-    */
+        Indicates whether a loading indicator should be shown in the picker.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the filter type of the component.
-    */
+        Defines the filter type of the component.
+        */
   filter!: 'StartsWithPerTerm' | 'StartsWith' | 'Contains' | 'None';
-
   /**
-     Defines whether the clear icon of the combobox will be shown.
-    */
+        Defines whether the clear icon of the combobox will be shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showClearIcon!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component
-    */
+        Receives id(or many ids) of the elements that label the component
+        */
   accessibleNameRef!: string;
 
   /**
@@ -1943,7 +1913,9 @@ exports[`Snapshot test Main Custom List Item should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -1980,21 +1952,20 @@ import { ListItemAccessibilityAttributes } from '@ui5/webcomponents/dist/ListIte
 })
 class CustomListItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -2002,36 +1973,33 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the item is movable.
-    */
+        Defines whether the item is movable.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   movable!: boolean;
-
   /**
-     Defines the text alternative of the component.
+        Defines the text alternative of the component.
 
 **Note**: If not provided a default text alternative will be set, if present.
-    */
+        */
   accessibleName!: string;
 
   /**
@@ -2061,7 +2029,9 @@ exports[`Snapshot test Main Date Picker should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -2128,9 +2098,9 @@ import {
 })
 class DatePickerComponent {
   /**
-     Sets a calendar type used for display.
+        Sets a calendar type used for display.
 If not set, the calendar type of the global configuration is used.
-    */
+        */
   primaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2138,11 +2108,10 @@ If not set, the calendar type of the global configuration is used.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Defines the secondary calendar type.
+        Defines the secondary calendar type.
 If not set, the calendar will only show the primary calendar type.
-    */
+        */
   secondaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2150,88 +2119,79 @@ If not set, the calendar will only show the primary calendar type.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Determines the format, displayed in the input field.
-    */
+        Determines the format, displayed in the input field.
+        */
   formatPattern!: string;
-
   /**
-     Determines the minimum date available for selection.
+        Determines the minimum date available for selection.
 
 **Note:** If the formatPattern property is not set, the minDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   minDate!: string;
-
   /**
-     Determines the maximum date available for selection.
+        Determines the maximum date available for selection.
 
 **Note:** If the formatPattern property is not set, the maxDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   maxDate!: string;
-
   /**
-     Defines a formatted date value.
-    */
+        Defines a formatted date value.
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Determines whether the component is displayed as disabled.
-    */
+        Determines whether the component is displayed as disabled.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines whether the component is displayed as read-only.
-    */
+        Determines whether the component is displayed as read-only.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines a short hint, intended to aid the user with data entry when the
+        Defines a short hint, intended to aid the user with data entry when the
 component has no value.
 
 **Note:** When no placeholder is set, the format pattern is displayed as a placeholder.
 Passing an empty string as the value of this property will make the component appear empty - without placeholder or format pattern.
-    */
+        */
   placeholder!: string | undefined;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the visibility of the week numbers column.
+        Defines the visibility of the week numbers column.
 
 **Note:** For calendars other than Gregorian,
 the week numbers are not displayed regardless of what is set.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideWeekNumbers!: boolean;
-
   /**
-     Defines the open or closed state of the popover.
-    */
+        Defines the open or closed state of the popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the aria-label attribute for the component.
-    */
+        Defines the aria-label attribute for the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -2281,7 +2241,9 @@ exports[`Snapshot test Main Date Range Picker should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -2350,9 +2312,9 @@ import DateRangePicker from '@ui5/webcomponents/dist/DateRangePicker.js';
 })
 class DateRangePickerComponent {
   /**
-     Sets a calendar type used for display.
+        Sets a calendar type used for display.
 If not set, the calendar type of the global configuration is used.
-    */
+        */
   primaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2360,11 +2322,10 @@ If not set, the calendar type of the global configuration is used.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Defines the secondary calendar type.
+        Defines the secondary calendar type.
 If not set, the calendar will only show the primary calendar type.
-    */
+        */
   secondaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2372,94 +2333,84 @@ If not set, the calendar will only show the primary calendar type.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Determines the format, displayed in the input field.
-    */
+        Determines the format, displayed in the input field.
+        */
   formatPattern!: string;
-
   /**
-     Determines the minimum date available for selection.
+        Determines the minimum date available for selection.
 
 **Note:** If the formatPattern property is not set, the minDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   minDate!: string;
-
   /**
-     Determines the maximum date available for selection.
+        Determines the maximum date available for selection.
 
 **Note:** If the formatPattern property is not set, the maxDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   maxDate!: string;
-
   /**
-     Defines a formatted date value.
-    */
+        Defines a formatted date value.
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Determines whether the component is displayed as disabled.
-    */
+        Determines whether the component is displayed as disabled.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines whether the component is displayed as read-only.
-    */
+        Determines whether the component is displayed as read-only.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines a short hint, intended to aid the user with data entry when the
+        Defines a short hint, intended to aid the user with data entry when the
 component has no value.
 
 **Note:** When no placeholder is set, the format pattern is displayed as a placeholder.
 Passing an empty string as the value of this property will make the component appear empty - without placeholder or format pattern.
-    */
+        */
   placeholder!: string | undefined;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the visibility of the week numbers column.
+        Defines the visibility of the week numbers column.
 
 **Note:** For calendars other than Gregorian,
 the week numbers are not displayed regardless of what is set.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideWeekNumbers!: boolean;
-
   /**
-     Defines the open or closed state of the popover.
-    */
+        Defines the open or closed state of the popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the aria-label attribute for the component.
-    */
+        Defines the aria-label attribute for the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Determines the symbol which separates the dates.
+        Determines the symbol which separates the dates.
 If not supplied, the default time interval delimiter for the current locale will be used.
-    */
+        */
   delimiter!: string;
 
   /**
@@ -2509,7 +2460,9 @@ exports[`Snapshot test Main Date Time Picker should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -2576,9 +2529,9 @@ import DateTimePicker from '@ui5/webcomponents/dist/DateTimePicker.js';
 })
 class DateTimePickerComponent {
   /**
-     Sets a calendar type used for display.
+        Sets a calendar type used for display.
 If not set, the calendar type of the global configuration is used.
-    */
+        */
   primaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2586,11 +2539,10 @@ If not set, the calendar type of the global configuration is used.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Defines the secondary calendar type.
+        Defines the secondary calendar type.
 If not set, the calendar will only show the primary calendar type.
-    */
+        */
   secondaryCalendarType!:
     | 'Gregorian'
     | 'Islamic'
@@ -2598,88 +2550,79 @@ If not set, the calendar will only show the primary calendar type.
     | 'Buddhist'
     | 'Persian'
     | undefined;
-
   /**
-     Determines the format, displayed in the input field.
-    */
+        Determines the format, displayed in the input field.
+        */
   formatPattern!: string;
-
   /**
-     Determines the minimum date available for selection.
+        Determines the minimum date available for selection.
 
 **Note:** If the formatPattern property is not set, the minDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   minDate!: string;
-
   /**
-     Determines the maximum date available for selection.
+        Determines the maximum date available for selection.
 
 **Note:** If the formatPattern property is not set, the maxDate value must be provided in the ISO date format (YYYY-MM-dd).
-    */
+        */
   maxDate!: string;
-
   /**
-     Defines a formatted date value.
-    */
+        Defines a formatted date value.
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Determines whether the component is displayed as disabled.
-    */
+        Determines whether the component is displayed as disabled.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines whether the component is displayed as read-only.
-    */
+        Determines whether the component is displayed as read-only.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines a short hint, intended to aid the user with data entry when the
+        Defines a short hint, intended to aid the user with data entry when the
 component has no value.
 
 **Note:** When no placeholder is set, the format pattern is displayed as a placeholder.
 Passing an empty string as the value of this property will make the component appear empty - without placeholder or format pattern.
-    */
+        */
   placeholder!: string | undefined;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the visibility of the week numbers column.
+        Defines the visibility of the week numbers column.
 
 **Note:** For calendars other than Gregorian,
 the week numbers are not displayed regardless of what is set.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideWeekNumbers!: boolean;
-
   /**
-     Defines the open or closed state of the popover.
-    */
+        Defines the open or closed state of the popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the aria-label attribute for the component.
-    */
+        Defines the aria-label attribute for the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -2729,7 +2672,9 @@ exports[`Snapshot test Main Dialog should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -2779,61 +2724,56 @@ import { PopupBeforeCloseEventDetail } from '@ui5/webcomponents/dist/Popup.js';
 })
 class DialogComponent {
   /**
-     Defines the ID of the HTML Element, which will get the initial focus.
+        Defines the ID of the HTML Element, which will get the initial focus.
 
 **Note:** If an element with \`autofocus\` attribute is added inside the component,
 \`initialFocus\` won't take effect.
-    */
+        */
   initialFocus!: string;
-
   /**
-     Defines if the focus should be returned to the previously focused element,
+        Defines if the focus should be returned to the previously focused element,
 when the popup closes.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventFocusRestore!: boolean;
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Allows setting a custom role.
-    */
+        Allows setting a custom role.
+        */
   accessibleRole!: 'None' | 'Dialog' | 'AlertDialog';
-
   /**
-     Indicates whether initial focus should be prevented.
-    */
+        Indicates whether initial focus should be prevented.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventInitialFocus!: boolean;
-
   /**
-     Indicates if the element is open
-    */
+        Indicates if the element is open
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the header text.
+        Defines the header text.
 
 **Note:** If \`header\` slot is provided, the \`headerText\` is ignored.
-    */
+        */
   headerText!: string;
-
   /**
-     Determines whether the component should be stretched to fullscreen.
+        Determines whether the component should be stretched to fullscreen.
 
 **Note:** The component will be stretched to approximately
 90% of the viewport.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   stretch!: boolean;
-
   /**
-     Determines whether the component is draggable.
+        Determines whether the component is draggable.
 If this property is set to true, the Dialog will be draggable by its header.
 
 **Note:** The component can be draggable only in desktop mode.
@@ -2841,26 +2781,26 @@ If this property is set to true, the Dialog will be draggable by its header.
 **Note:** This property overrides the default HTML \\"draggable\\" attribute native behavior.
 When \\"draggable\\" is set to true, the native browser \\"draggable\\"
 behavior is prevented and only the Dialog custom logic (\\"draggable by its header\\") works.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   draggable!: boolean;
-
   /**
-     Configures the component to be resizable.
+        Configures the component to be resizable.
 If this property is set to true, the Dialog will have a resize handle in its bottom right corner in LTR languages.
 In RTL languages, the resize handle will be placed in the bottom left corner.
 
 **Note:** The component can be resizable only in desktop mode.
 
 **Note:** Upon resizing, externally defined height and width styling will be ignored.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   resizable!: boolean;
-
   /**
-     Defines the state of the \`Dialog\`.
+        Defines the state of the \`Dialog\`.
 
 **Note:** If \`\\"Negative\\"\` and \`\\"Critical\\"\` states is set, it will change the
 accessibility role to \\"alertdialog\\", if the accessibleRole property is set to \`\\"Dialog\\"\`.
-    */
+        */
   state!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
 
   /**
@@ -2902,7 +2842,9 @@ exports[`Snapshot test Main File Uploader should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -2944,49 +2886,45 @@ import {
 })
 class FileUploaderComponent {
   /**
-     Comma-separated list of file types that the component should accept.
+        Comma-separated list of file types that the component should accept.
 
 **Note:** Please make sure you are adding the \`.\` in front on the file type, e.g. \`.png\` in case you want to accept png's only.
-    */
+        */
   accept!: string;
-
   /**
-     If set to \\"true\\", the input field of component will not be rendered. Only the default slot that is passed will be rendered.
-    */
+        If set to \\"true\\", the input field of component will not be rendered. Only the default slot that is passed will be rendered.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideInput!: boolean;
-
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Allows multiple files to be chosen.
-    */
+        Allows multiple files to be chosen.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   multiple!: boolean;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the component has no value.
-    */
+        Defines a short hint intended to aid the user with data entry when the component has no value.
+        */
   placeholder!: string;
-
   /**
-     Defines the name/names of the file/files to upload.
-    */
+        Defines the name/names of the file/files to upload.
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
 
   /**
@@ -3043,14 +2981,13 @@ import FormGroup from '@ui5/webcomponents/dist/FormGroup.js';
 })
 class FormGroupComponent {
   /**
-     Defines header text of the component.
-    */
+        Defines header text of the component.
+        */
   headerText!: string;
-
   /**
-     Defines column span of the component,
+        Defines column span of the component,
 e.g how many columns the group should span to.
-    */
+        */
   columnSpan!: number | undefined;
 
   private elementRef: ElementRef<FormGroup> = inject(ElementRef);
@@ -3090,13 +3027,13 @@ import FormItem from '@ui5/webcomponents/dist/FormItem.js';
 })
 class FormItemComponent {
   /**
-     Defines the column span of the component,
+        Defines the column span of the component,
 e.g how many columns the component should span to.
 
 **Note:** The column span should be a number between 1 and the available columns of the FormGroup (when items are placed in a group)
 or the Form. The available columns can be affected by the FormGroup#columnSpan and/or the Form#layout.
 A number bigger than the available columns won't take effect.
-    */
+        */
   columnSpan!: number | undefined;
 
   private elementRef: ElementRef<FormItem> = inject(ElementRef);
@@ -3136,18 +3073,17 @@ import Form from '@ui5/webcomponents/dist/Form.js';
 })
 class FormComponent {
   /**
-     Defines the number of columns to distribute the form content by breakpoint.
+        Defines the number of columns to distribute the form content by breakpoint.
 
 Supported values:
 - \`S\` - 1 column by default (1 column is recommended)
 - \`M\` - 1 column by default (up to 2 columns are recommended)
 - \`L\` - 2 columns by default (up to 3 columns are recommended)
 - \`XL\` - 2 columns by default (up to 6 columns  are recommended)
-    */
+        */
   layout!: string;
-
   /**
-     Defines the width proportion of the labels and fields of a FormItem by breakpoint.
+        Defines the width proportion of the labels and fields of a FormItem by breakpoint.
 
 By default, the labels take 4/12 (or 1/3) of the form item in M,L and XL sizes,
 and 12/12 in S size, e.g in S the label is on top of its associated field.
@@ -3155,23 +3091,21 @@ and 12/12 in S size, e.g in S the label is on top of its associated field.
 The supported values are between 1 and 12. Greater the number, more space the label will use.
 
 **Note:** If \\"12\\" is set, the label will be displayed on top of its assosiated field.
-    */
+        */
   labelSpan!: string;
-
   /**
-     Defines the header text of the component.
+        Defines the header text of the component.
 
 **Note:** The property gets overridden by the \`header\` slot.
-    */
+        */
   headerText!: string;
-
   /**
-     Defines the vertical spacing between form items.
+        Defines the vertical spacing between form items.
 
 **Note:** If the Form is meant to be switched between \\"non-edit\\" and \\"edit\\" modes,
 we recommend using \\"Large\\" item spacing in \\"non-edit\\" mode, and \\"Normal\\" - for \\"edit\\" mode,
 to avoid \\"jumping\\" effect, caused by the hight difference between texts in \\"non-edit\\" mode and the input fields in \\"edit\\" mode.
-    */
+        */
   itemSpacing!: 'Normal' | 'Large';
 
   private elementRef: ElementRef<Form> = inject(ElementRef);
@@ -3195,7 +3129,9 @@ exports[`Snapshot test Main Icon should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -3211,8 +3147,8 @@ import Icon from '@ui5/webcomponents/dist/Icon.js';
 })
 class IconComponent {
   /**
-     Defines the component semantic design.
-    */
+        Defines the component semantic design.
+        */
   design!:
     | 'Contrast'
     | 'Critical'
@@ -3222,9 +3158,8 @@ class IconComponent {
     | 'Neutral'
     | 'NonInteractive'
     | 'Positive';
-
   /**
-     Defines the unique identifier (icon name) of the component.
+        Defines the unique identifier (icon name) of the component.
 
 To browse all available icons, see the
 [SAP Icons](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html),
@@ -3245,28 +3180,26 @@ you need to set the \`business-suite\` prefix in front of the icon's name.
 
 Example:
 \`name='business-suite/3d'\`, \`name='business-suite/1x2-grid-layout'\`, \`name='business-suite/4x4-grid-layout'\`.
-    */
+        */
   name!: string;
-
   /**
-     Defines the text alternative of the component.
+        Defines the text alternative of the component.
 If not provided a default text alternative will be set, if present.
 
 **Note:** Every icon should have a text alternative in order to
 calculate its accessible name.
-    */
+        */
   accessibleName!: string;
-
   /**
-     Defines whether the component should have a tooltip.
+        Defines whether the component should have a tooltip.
 
 **Note:** The tooltip text should be provided via the \`accessible-name\` property.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showTooltip!: boolean;
-
   /**
-     Defines the mode of the component.
-    */
+        Defines the mode of the component.
+        */
   mode!: 'Image' | 'Decorative' | 'Interactive';
 
   private elementRef: ElementRef<Icon> = inject(ElementRef);
@@ -3293,7 +3226,9 @@ exports[`Snapshot test Main Input should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -3364,38 +3299,37 @@ import {
 })
 class InputComponent {
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the
+        Defines a short hint intended to aid the user with data entry when the
 component has no value.
-    */
+        */
   placeholder!: string;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines whether the value will be autcompleted to match an item
-    */
+        Defines whether the value will be autcompleted to match an item
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noTypeahead!: boolean;
-
   /**
-     Defines the HTML type of the component.
+        Defines the HTML type of the component.
 
 **Notes:**
 
@@ -3403,63 +3337,57 @@ but still provides visual feedback upon user interaction.
 and the current language settings, especially for type \`Number\`.
 - The property is mostly intended to be used with touch devices
 that use different soft keyboard layouts depending on the given input type.
-    */
+        */
   type!: 'Text' | 'Email' | 'Number' | 'Password' | 'Tel' | 'URL' | 'Search';
-
   /**
-     Defines the value of the component.
+        Defines the value of the component.
 
 **Note:** The property is updated upon typing.
-    */
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines whether the component should show suggestions, if such are present.
+        Defines whether the component should show suggestions, if such are present.
 
 **Note:** You need to import the \`InputSuggestions\` module
 from \`\\"@ui5/webcomponents/dist/features/InputSuggestions.js\\"\` to enable this functionality.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showSuggestions!: boolean;
-
   /**
-     Sets the maximum number of characters available in the input field.
+        Sets the maximum number of characters available in the input field.
 
 **Note:** This property is not compatible with the ui5-input type InputType.Number. If the ui5-input type is set to Number, the maxlength value is ignored.
-    */
+        */
   maxlength!: number | undefined;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the input.
-    */
+        Receives id(or many ids) of the elements that label the input.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines whether the clear icon of the input will be shown.
-    */
+        Defines whether the clear icon of the input will be shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showClearIcon!: boolean;
-
   /**
-     Defines whether the suggestions picker is open.
+        Defines whether the suggestions picker is open.
 The picker will not open if the \`showSuggestions\` property is set to \`false\`, the input is disabled or the input is readonly.
 The picker will close automatically and \`close\` event will be fired if the input is not in the viewport.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
 
   /**
@@ -3516,7 +3444,9 @@ exports[`Snapshot test Main Label should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -3532,33 +3462,32 @@ import Label from '@ui5/webcomponents/dist/Label.js';
 })
 class LabelComponent {
   /**
-     Defines the labeled input by providing its ID.
+        Defines the labeled input by providing its ID.
 
 **Note:** Can be used with both \`ui5-input\` and native input.
-    */
+        */
   for!: string;
-
   /**
-     Defines whether colon is added to the component text.
+        Defines whether colon is added to the component text.
 
 **Note:** Usually used in forms.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showColon!: boolean;
-
   /**
-     Defines whether an asterisk character is added to the component text.
+        Defines whether an asterisk character is added to the component text.
 
 **Note:** Usually indicates that user input (bound with the \`for\` property) is required.
 In that case the \`required\` property of
 the corresponding input should also be set.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines how the text of a component will be displayed when there is not enough space.
+        Defines how the text of a component will be displayed when there is not enough space.
 
 **Note:** for option \\"Normal\\" the text will wrap and the words will not be broken based on hyphenation.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
 
   private elementRef: ElementRef<Label> = inject(ElementRef);
@@ -3583,7 +3512,9 @@ exports[`Snapshot test Main Link should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -3627,26 +3558,24 @@ import {
 })
 class LinkComponent {
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** When disabled, the click event cannot be triggered by the user.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the tooltip of the component.
-    */
+        Defines the tooltip of the component.
+        */
   tooltip!: string;
-
   /**
-     Defines the component href.
+        Defines the component href.
 
 **Note:** Standard hyperlink behavior is supported.
-    */
+        */
   href!: string;
-
   /**
-     Defines the component target.
+        Defines the component target.
 
 **Notes:**
 
@@ -3657,42 +3586,36 @@ class LinkComponent {
 - \`_search\`
 
 **This property must only be used when the \`href\` property is set.**
-    */
+        */
   target!: string;
-
   /**
-     Defines the component design.
+        Defines the component design.
 
 **Note:** Avaialble options are \`Default\`, \`Subtle\`, and \`Emphasized\`.
-    */
+        */
   design!: 'Default' | 'Subtle' | 'Emphasized';
-
   /**
-     Defines how the text of a component will be displayed when there is not enough space.
+        Defines how the text of a component will be displayed when there is not enough space.
 
 **Note:** By default the text will wrap. If \\"None\\" is set - the text will truncate.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the input
-    */
+        Receives id(or many ids) of the elements that label the input
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the ARIA role of the component.
+        Defines the ARIA role of the component.
 
 **Note:** Use the <code>LinkAccessibleRole.Button</code> role in cases when navigation is not expected to occur and the href property is not defined.
-    */
+        */
   accessibleRole!: 'Link' | 'Button';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **expanded**: Indicates whether the button, or another grouping element it controls, is currently expanded or collapsed.
@@ -3700,7 +3623,7 @@ Accepts the following string values: \`true\` or \`false\`.
 
 - **hasPopup**: Indicates the availability and type of interactive popup element, such as menu or dialog, that can be triggered by the button.
 Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\` or \`tree\`.
-    */
+        */
   accessibilityAttributes!: LinkAccessibilityAttributes;
 
   /**
@@ -3746,13 +3669,12 @@ import ListItemGroup from '@ui5/webcomponents/dist/ListItemGroup.js';
 })
 class ListItemGroupComponent {
   /**
-     Defines the header text of the <code>ui5-li-group</code>.
-    */
+        Defines the header text of the <code>ui5-li-group</code>.
+        */
   headerText!: string;
-
   /**
-     Defines the accessible name of the header.
-    */
+        Defines the accessible name of the header.
+        */
   headerAccessibleName!: string;
 
   private elementRef: ElementRef<ListItemGroup> = inject(ElementRef);
@@ -3777,7 +3699,9 @@ exports[`Snapshot test Main List should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -3849,25 +3773,23 @@ import {
 })
 class ListComponent {
   /**
-     Defines the component header text.
+        Defines the component header text.
 
 **Note:** If \`header\` is set this property is ignored.
-    */
+        */
   headerText!: string;
-
   /**
-     Defines the footer text.
-    */
+        Defines the footer text.
+        */
   footerText!: string;
-
   /**
-     Determines whether the component is indented.
-    */
+        Determines whether the component is indented.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   indent!: boolean;
-
   /**
-     Defines the selection mode of the component.
-    */
+        Defines the selection mode of the component.
+        */
   selectionMode!:
     | 'None'
     | 'Single'
@@ -3876,58 +3798,50 @@ class ListComponent {
     | 'SingleAuto'
     | 'Multiple'
     | 'Delete';
-
   /**
-     Defines the text that is displayed when the component contains no items.
-    */
+        Defines the text that is displayed when the component contains no items.
+        */
   noDataText!: string;
-
   /**
-     Defines the item separator style that is used.
-    */
+        Defines the item separator style that is used.
+        */
   separators!: 'All' | 'Inner' | 'None';
-
   /**
-     Defines whether the component will have growing capability either by pressing a \`More\` button,
+        Defines whether the component will have growing capability either by pressing a \`More\` button,
 or via user scroll. In both cases \`load-more\` event is fired.
 
 **Restrictions:** \`growing=\\"Scroll\\"\` is not supported for Internet Explorer,
 on IE the component will fallback to \`growing=\\"Button\\"\`.
-    */
+        */
   growing!: 'Button' | 'Scroll' | 'None';
-
   /**
-     Defines the text that will be displayed inside the growing button.
+        Defines the text that will be displayed inside the growing button.
 
 **Note:** If not specified a built-in text will be displayed.
 
 **Note:** This property takes effect if the \`growing\` property is set to the \`Button\`.
-    */
+        */
   growingButtonText!: string;
-
   /**
-     Defines if the component would display a loading indicator over the list.
-    */
+        Defines if the component would display a loading indicator over the list.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the loading indicator will show up for this component.
-    */
+        Defines the delay in milliseconds, after which the loading indicator will show up for this component.
+        */
   loadingDelay!: number;
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines the IDs of the elements that label the input.
-    */
+        Defines the IDs of the elements that label the input.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the accessible role of the component.
-    */
+        Defines the accessible role of the component.
+        */
   accessibleRole!: 'List' | 'Menu' | 'Tree' | 'ListBox';
 
   /**
@@ -4001,7 +3915,9 @@ exports[`Snapshot test Main Menu Item should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -4050,21 +3966,20 @@ import MenuItem from '@ui5/webcomponents/dist/MenuItem.js';
 })
 class MenuItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -4072,79 +3987,72 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip for the menu item.
-    */
+        Defines the text of the tooltip for the menu item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines the text of the tree item.
-    */
+        Defines the text of the tree item.
+        */
   text!: string;
-
   /**
-     Defines the \`additionalText\`, displayed in the end of the menu item.
+        Defines the \`additionalText\`, displayed in the end of the menu item.
 
 **Note:** The additional text will not be displayed if there are items added in \`items\` slot or there are
 components added to \`endContent\` slot.
 
 The priority of what will be displayed at the end of the menu item is as follows:
 sub-menu arrow (if there are items added in \`items\` slot) -> components added in \`endContent\` -> text set to \`additionalText\`.
-    */
+        */
   additionalText!: string;
-
   /**
-     Defines the icon to be displayed as graphical element within the component.
+        Defines the icon to be displayed as graphical element within the component.
 The SAP-icons font provides numerous options.
 
 **Example:**
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether a visual separator should be rendered before the item.
-    */
+        Defines whether a visual separator should be rendered before the item.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   startsSection!: boolean;
-
   /**
-     Defines whether \`ui5-menu-item\` is in disabled state.
+        Defines whether \`ui5-menu-item\` is in disabled state.
 
 **Note:** A disabled \`ui5-menu-item\` is noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
+        Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
 
 **Note:** If set to \`true\` a \`ui5-busy-indicator\` component will be displayed into the related one to the current \`ui5-menu-item\` sub-menu popover.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
-    */
+        Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover.
+        */
   loadingDelay!: number;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
 
   /**
@@ -4174,7 +4082,9 @@ exports[`Snapshot test Main Menu should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -4209,30 +4119,28 @@ import {
 })
 class MenuComponent {
   /**
-     Defines the header text of the menu (displayed on mobile).
-    */
+        Defines the header text of the menu (displayed on mobile).
+        */
   headerText!: string;
-
   /**
-     Indicates if the menu is open
-    */
+        Indicates if the menu is open
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines if a loading indicator would be displayed inside the corresponding ui5-menu popover.
-    */
+        Defines if a loading indicator would be displayed inside the corresponding ui5-menu popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   loading!: boolean;
-
   /**
-     Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover..
-    */
+        Defines the delay in milliseconds, after which the loading indicator will be displayed inside the corresponding ui5-menu popover..
+        */
   loadingDelay!: number;
-
   /**
-     Defines the ID or DOM Reference of the element at which the menu is shown.
+        Defines the ID or DOM Reference of the element at which the menu is shown.
 When using this attribute in a declarative way, you must only use the \`id\` (as a string) of the element at which you want to show the popover.
 You can only set the \`opener\` attribute to a DOM Reference when using JavaScript.
-    */
+        */
   opener!: HTMLElement | string;
 
   /**
@@ -4282,7 +4190,9 @@ exports[`Snapshot test Main Message Strip should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -4300,8 +4210,8 @@ import MessageStrip from '@ui5/webcomponents/dist/MessageStrip.js';
 })
 class MessageStripComponent {
   /**
-     Defines the component type.
-    */
+        Defines the component type.
+        */
   design!:
     | 'Information'
     | 'Positive'
@@ -4309,25 +4219,24 @@ class MessageStripComponent {
     | 'Critical'
     | 'ColorSet1'
     | 'ColorSet2';
-
   /**
-     Defines the color scheme of the component.
+        Defines the color scheme of the component.
 There are 10 predefined schemes.
 To use one you can set a number from \`\\"1\\"\` to \`\\"10\\"\`. The \`colorScheme\` \`\\"1\\"\` will be set by default.
-    */
+        */
   colorScheme!: string;
-
   /**
-     Defines whether the MessageStrip will show an icon in the beginning.
+        Defines whether the MessageStrip will show an icon in the beginning.
 You can directly provide an icon with the \`icon\` slot. Otherwise, the default icon for the type will be used.
 
  * **Note:** If <code>MessageStripDesign.ColorSet1</code> or <code>MessageStripDesign.ColorSet2</code> value is set to the <code>design</code> property, default icon will not be presented.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideIcon!: boolean;
-
   /**
-     Defines whether the MessageStrip renders close button.
-    */
+        Defines whether the MessageStrip renders close button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideCloseButton!: boolean;
 
   /**
@@ -4373,8 +4282,8 @@ import MultiComboBoxGroupItem from '@ui5/webcomponents/dist/MultiComboBoxGroupIt
 })
 class MultiComboBoxGroupItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
 
   private elementRef: ElementRef<MultiComboBoxGroupItem> = inject(ElementRef);
@@ -4398,7 +4307,9 @@ exports[`Snapshot test Main Multi Combo Box Item should match the snapshot 1`] =
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -4414,18 +4325,17 @@ import MultiComboBoxItem from '@ui5/webcomponents/dist/MultiComboBoxItem.js';
 })
 class MultiComboBoxItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the additional text of the component.
-    */
+        Defines the additional text of the component.
+        */
   additionalText!: string;
-
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<MultiComboBoxItem> = inject(ElementRef);
@@ -4450,7 +4360,9 @@ exports[`Snapshot test Main Multi Combo Box should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -4512,85 +4424,79 @@ import {
 })
 class MultiComboBoxComponent {
   /**
-     Defines the value of the component.
+        Defines the value of the component.
 
 **Note:** The property is updated upon typing.
-    */
+        */
   value!: string;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
 **Note:** When the component is used inside a form element,
 the value is sent as the first element in the form data, even if it's empty.
-    */
+        */
   name!: string;
-
   /**
-     Defines whether the value will be autcompleted to match an item
-    */
+        Defines whether the value will be autcompleted to match an item
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noTypeahead!: boolean;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the
+        Defines a short hint intended to aid the user with data entry when the
 component has no value.
-    */
+        */
   placeholder!: string;
-
   /**
-     Defines if the user input will be prevented, if no matching item has been found
-    */
+        Defines if the user input will be prevented, if no matching item has been found
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noValidation!: boolean;
-
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines the filter type of the component.
-    */
+        Defines the filter type of the component.
+        */
   filter!: 'StartsWithPerTerm' | 'StartsWith' | 'Contains' | 'None';
-
   /**
-     Defines whether the clear icon of the multi-combobox will be shown.
-    */
+        Defines whether the clear icon of the multi-combobox will be shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showClearIcon!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Determines if the select all checkbox is visible on top of suggestions.
-    */
+        Determines if the select all checkbox is visible on top of suggestions.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showSelectAll!: boolean;
 
   /**
@@ -4642,7 +4548,9 @@ exports[`Snapshot test Main Multi Input should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -4720,38 +4628,37 @@ import {
 })
 class MultiInputComponent {
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the
+        Defines a short hint intended to aid the user with data entry when the
 component has no value.
-    */
+        */
   placeholder!: string;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines whether the value will be autcompleted to match an item
-    */
+        Defines whether the value will be autcompleted to match an item
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noTypeahead!: boolean;
-
   /**
-     Defines the HTML type of the component.
+        Defines the HTML type of the component.
 
 **Notes:**
 
@@ -4759,71 +4666,65 @@ but still provides visual feedback upon user interaction.
 and the current language settings, especially for type \`Number\`.
 - The property is mostly intended to be used with touch devices
 that use different soft keyboard layouts depending on the given input type.
-    */
+        */
   type!: 'Text' | 'Email' | 'Number' | 'Password' | 'Tel' | 'URL' | 'Search';
-
   /**
-     Defines the value of the component.
+        Defines the value of the component.
 
 **Note:** The property is updated upon typing.
-    */
+        */
   value!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
 **Note:** When the component is used inside a form element,
 the value is sent as the first element in the form data, even if it's empty.
-    */
+        */
   name!: string;
-
   /**
-     Defines whether the component should show suggestions, if such are present.
+        Defines whether the component should show suggestions, if such are present.
 
 **Note:** You need to import the \`InputSuggestions\` module
 from \`\\"@ui5/webcomponents/dist/features/InputSuggestions.js\\"\` to enable this functionality.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showSuggestions!: boolean;
-
   /**
-     Sets the maximum number of characters available in the input field.
+        Sets the maximum number of characters available in the input field.
 
 **Note:** This property is not compatible with the ui5-input type InputType.Number. If the ui5-input type is set to Number, the maxlength value is ignored.
-    */
+        */
   maxlength!: number | undefined;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the input.
-    */
+        Receives id(or many ids) of the elements that label the input.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines whether the clear icon of the input will be shown.
-    */
+        Defines whether the clear icon of the input will be shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showClearIcon!: boolean;
-
   /**
-     Defines whether the suggestions picker is open.
+        Defines whether the suggestions picker is open.
 The picker will not open if the \`showSuggestions\` property is set to \`false\`, the input is disabled or the input is readonly.
 The picker will close automatically and \`close\` event will be fired if the input is not in the viewport.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Determines whether a value help icon will be visualized in the end of the input.
+        Determines whether a value help icon will be visualized in the end of the input.
 Pressing the icon will fire \`value-help-trigger\` event.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showValueHelpIcon!: boolean;
 
   /**
@@ -4891,7 +4792,9 @@ exports[`Snapshot test Main Option Custom should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -4907,25 +4810,23 @@ import OptionCustom from '@ui5/webcomponents/dist/OptionCustom.js';
 })
 class OptionCustomComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the text, displayed inside the \`ui5-select\` input filed
+        Defines the text, displayed inside the \`ui5-select\` input filed
 when the option gets selected.
-    */
+        */
   displayText!: string;
-
   /**
-     Defines the value of the \`ui5-select\` inside an HTML Form element when this component is selected.
+        Defines the value of the \`ui5-select\` inside an HTML Form element when this component is selected.
 For more information on HTML Form support, see the \`name\` property of \`ui5-select\`.
-    */
+        */
   value!: string;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
 
   private elementRef: ElementRef<OptionCustom> = inject(ElementRef);
@@ -4949,7 +4850,9 @@ exports[`Snapshot test Main Option should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -4965,33 +4868,30 @@ import Option from '@ui5/webcomponents/dist/Option.js';
 })
 class OptionComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the value of the \`ui5-select\` inside an HTML Form element when this component is selected.
+        Defines the value of the \`ui5-select\` inside an HTML Form element when this component is selected.
 For more information on HTML Form support, see the \`name\` property of \`ui5-select\`.
-    */
+        */
   value!: string;
-
   /**
-     Defines the \`icon\` source URI.
+        Defines the \`icon\` source URI.
 
 **Note:**
 SAP-icons font provides numerous built-in icons. To find all the available icons, see the
 [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the \`additionalText\`, displayed in the end of the list item.
-    */
+        Defines the \`additionalText\`, displayed in the end of the list item.
+        */
   additionalText!: string;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
 
   private elementRef: ElementRef<Option> = inject(ElementRef);
@@ -5016,7 +4916,9 @@ exports[`Snapshot test Main Panel should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -5052,53 +4954,50 @@ import Panel from '@ui5/webcomponents/dist/Panel.js';
 })
 class PanelComponent {
   /**
-     This property is used to set the header text of the component.
+        This property is used to set the header text of the component.
 The text is visible in both expanded and collapsed states.
 
 **Note:** This property is overridden by the \`header\` slot.
-    */
+        */
   headerText!: string;
-
   /**
-     Determines whether the component is in a fixed state that is not
+        Determines whether the component is in a fixed state that is not
 expandable/collapsible by user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   fixed!: boolean;
-
   /**
-     Indicates whether the component is collapsed and only the header is displayed.
-    */
+        Indicates whether the component is collapsed and only the header is displayed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   collapsed!: boolean;
-
   /**
-     Indicates whether the transition between the expanded and the collapsed state of the component is animated. By default the animation is enabled.
-    */
+        Indicates whether the transition between the expanded and the collapsed state of the component is animated. By default the animation is enabled.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   noAnimation!: boolean;
-
   /**
-     Sets the accessible ARIA role of the component.
+        Sets the accessible ARIA role of the component.
 Depending on the usage, you can change the role from the default \`Form\`
 to \`Region\` or \`Complementary\`.
-    */
+        */
   accessibleRole!: 'Complementary' | 'Form' | 'Region';
-
   /**
-     Defines the \\"aria-level\\" of component heading,
+        Defines the \\"aria-level\\" of component heading,
 set by the \`headerText\`.
-    */
+        */
   headerLevel!: 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6';
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Indicates whether the Panel header is sticky or not.
+        Indicates whether the Panel header is sticky or not.
 If stickyHeader is set to true, then whenever you scroll the content or
 the application, the header of the panel will be always visible and
 a solid color will be used for its design.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   stickyHeader!: boolean;
 
   /**
@@ -5128,7 +5027,9 @@ exports[`Snapshot test Main Popover should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -5184,89 +5085,81 @@ import { PopupBeforeCloseEventDetail } from '@ui5/webcomponents/dist/Popup.js';
 })
 class PopoverComponent {
   /**
-     Defines the ID of the HTML Element, which will get the initial focus.
+        Defines the ID of the HTML Element, which will get the initial focus.
 
 **Note:** If an element with \`autofocus\` attribute is added inside the component,
 \`initialFocus\` won't take effect.
-    */
+        */
   initialFocus!: string;
-
   /**
-     Defines if the focus should be returned to the previously focused element,
+        Defines if the focus should be returned to the previously focused element,
 when the popup closes.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventFocusRestore!: boolean;
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Allows setting a custom role.
-    */
+        Allows setting a custom role.
+        */
   accessibleRole!: 'None' | 'Dialog' | 'AlertDialog';
-
   /**
-     Indicates whether initial focus should be prevented.
-    */
+        Indicates whether initial focus should be prevented.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventInitialFocus!: boolean;
-
   /**
-     Indicates if the element is open
-    */
+        Indicates if the element is open
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the header text.
+        Defines the header text.
 
 **Note:** If \`header\` slot is provided, the \`headerText\` is ignored.
-    */
+        */
   headerText!: string;
-
   /**
-     Determines on which side the component is placed at.
-    */
+        Determines on which side the component is placed at.
+        */
   placement!: 'Start' | 'End' | 'Top' | 'Bottom';
-
   /**
-     Determines the horizontal alignment of the component.
-    */
+        Determines the horizontal alignment of the component.
+        */
   horizontalAlign!: 'Center' | 'Start' | 'End' | 'Stretch';
-
   /**
-     Determines the vertical alignment of the component.
-    */
+        Determines the vertical alignment of the component.
+        */
   verticalAlign!: 'Center' | 'Top' | 'Bottom' | 'Stretch';
-
   /**
-     Defines whether the component should close when
+        Defines whether the component should close when
 clicking/tapping outside of the popover.
 If enabled, it blocks any interaction with the background.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   modal!: boolean;
-
   /**
-     Determines whether the component arrow is hidden.
-    */
+        Determines whether the component arrow is hidden.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideArrow!: boolean;
-
   /**
-     Determines if there is no enough space, the component can be placed
+        Determines if there is no enough space, the component can be placed
 over the target.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   allowTargetOverlap!: boolean;
-
   /**
-     Defines the ID or DOM Reference of the element at which the popover is shown.
+        Defines the ID or DOM Reference of the element at which the popover is shown.
 When using this attribute in a declarative way, you must only use the \`id\` (as a string) of the element at which you want to show the popover.
 You can only set the \`opener\` attribute to a DOM Reference when using JavaScript.
-    */
+        */
   opener!: HTMLElement | string | undefined;
 
   /**
@@ -5307,7 +5200,9 @@ exports[`Snapshot test Main Progress Indicator should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -5335,36 +5230,33 @@ import ProgressIndicator from '@ui5/webcomponents/dist/ProgressIndicator.js';
 })
 class ProgressIndicatorComponent {
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines whether the component value is shown.
-    */
+        Defines whether the component value is shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideValue!: boolean;
-
   /**
-     Specifies the numerical value in percent for the length of the component.
+        Specifies the numerical value in percent for the length of the component.
 
 **Note:**
 If a value greater than 100 is provided, the percentValue is set to 100. In other cases of invalid value, percentValue is set to its default of 0.
-    */
+        */
   value!: number;
-
   /**
-     Specifies the text value to be displayed in the bar.
+        Specifies the text value to be displayed in the bar.
 
 **Note:**
 
 - If there is no value provided or the value is empty, the default percentage value is shown.
 - If \`hideValue\` property is \`true\` both the \`displayValue\` and \`value\` property values are not shown.
-    */
+        */
   displayValue!: string | null | undefined;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
 
   private elementRef: ElementRef<ProgressIndicator> = inject(ElementRef);
@@ -5389,7 +5281,9 @@ exports[`Snapshot test Main Radio Button should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -5434,46 +5328,44 @@ import RadioButton from '@ui5/webcomponents/dist/RadioButton.js';
 })
 class RadioButtonComponent {
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines whether the component is checked or not.
+        Defines whether the component is checked or not.
 
 **Note:** The property value can be changed with user interaction,
 either by clicking/tapping on the component,
 or by using the Space or Enter key.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   checked!: boolean;
-
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 Radio buttons with the same \`name\` will form a radio button group.
 
@@ -5482,31 +5374,27 @@ Radio buttons with the same \`name\` will form a radio button group.
 **Note:** The selection can be changed with \`ARROW_UP/DOWN\` and \`ARROW_LEFT/RIGHT\` keys between radio buttons in same group.
 
 **Note:** Only one radio button can be selected per group.
-    */
+        */
   name!: string;
-
   /**
-     Defines the form value of the component.
+        Defines the form value of the component.
 When a form with a radio button group is submitted, the group's value
 will be the value of the currently selected radio button.
-    */
+        */
   value!: string;
-
   /**
-     Defines whether the component text wraps when there is not enough space.
+        Defines whether the component text wraps when there is not enough space.
 
 **Note:** for option \\"Normal\\" the text will wrap and the words will not be broken based on hyphenation.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -5545,7 +5433,9 @@ exports[`Snapshot test Main Range Slider should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -5593,68 +5483,61 @@ import RangeSlider from '@ui5/webcomponents/dist/RangeSlider.js';
 })
 class RangeSliderComponent {
   /**
-     Defines the minimum value of the slider.
-    */
+        Defines the minimum value of the slider.
+        */
   min!: number;
-
   /**
-     Defines the maximum value of the slider.
-    */
+        Defines the maximum value of the slider.
+        */
   max!: number;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the size of the slider's selection intervals (e.g. min = 0, max = 10, step = 5 would result in possible selection of the values 0, 5, 10).
+        Defines the size of the slider's selection intervals (e.g. min = 0, max = 10, step = 5 would result in possible selection of the values 0, 5, 10).
 
 **Note:** If set to 0 the slider handle movement is disabled. When negative number or value other than a number, the component fallbacks to its default value.
-    */
+        */
   step!: number;
-
   /**
-     Displays a label with a value on every N-th step.
+        Displays a label with a value on every N-th step.
 
 **Note:** The step and tickmarks properties must be enabled.
 Example - if the step value is set to 2 and the label interval is also specified to 2 - then every second
 tickmark will be labelled, which means every 4th value number.
-    */
+        */
   labelInterval!: number;
-
   /**
-     Enables tickmarks visualization for each step.
+        Enables tickmarks visualization for each step.
 
 **Note:** The step must be a positive number.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showTickmarks!: boolean;
-
   /**
-     Enables handle tooltip displaying the current value.
-    */
+        Enables handle tooltip displaying the current value.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showTooltip!: boolean;
-
   /**
-     Defines whether the slider is in disabled state.
-    */
+        Defines whether the slider is in disabled state.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines start point of a selection - position of a first handle on the slider.
-    */
+        Defines start point of a selection - position of a first handle on the slider.
+        */
   startValue!: number;
-
   /**
-     Defines end point of a selection - position of a second handle on the slider.
-    */
+        Defines end point of a selection - position of a second handle on the slider.
+        */
   endValue!: number;
 
   /**
@@ -5698,7 +5581,9 @@ exports[`Snapshot test Main Rating Indicator should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -5734,54 +5619,50 @@ import RatingIndicator from '@ui5/webcomponents/dist/RatingIndicator.js';
 })
 class RatingIndicatorComponent {
   /**
-     The indicated value of the rating.
+        The indicated value of the rating.
 
 **Note:** If you set a number which is not round, it would be shown as follows:
 
 - 1.0 - 1.2 -> 1
 - 1.3 - 1.7 -> 1.5
 - 1.8 - 1.9 -> 2
-    */
+        */
   value!: number;
-
   /**
-     The number of displayed rating symbols.
-    */
+        The number of displayed rating symbols.
+        */
   max!: number;
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines the tooltip of the component.
-    */
+        Defines the tooltip of the component.
+        */
   tooltip!: string;
 
   /**
@@ -5811,7 +5692,9 @@ exports[`Snapshot test Main Responsive Popover should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -5867,89 +5750,81 @@ import ResponsivePopover from '@ui5/webcomponents/dist/ResponsivePopover.js';
 })
 class ResponsivePopoverComponent {
   /**
-     Defines the ID of the HTML Element, which will get the initial focus.
+        Defines the ID of the HTML Element, which will get the initial focus.
 
 **Note:** If an element with \`autofocus\` attribute is added inside the component,
 \`initialFocus\` won't take effect.
-    */
+        */
   initialFocus!: string;
-
   /**
-     Defines if the focus should be returned to the previously focused element,
+        Defines if the focus should be returned to the previously focused element,
 when the popup closes.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventFocusRestore!: boolean;
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Allows setting a custom role.
-    */
+        Allows setting a custom role.
+        */
   accessibleRole!: 'None' | 'Dialog' | 'AlertDialog';
-
   /**
-     Indicates whether initial focus should be prevented.
-    */
+        Indicates whether initial focus should be prevented.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventInitialFocus!: boolean;
-
   /**
-     Indicates if the element is open
-    */
+        Indicates if the element is open
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
-
   /**
-     Defines the header text.
+        Defines the header text.
 
 **Note:** If \`header\` slot is provided, the \`headerText\` is ignored.
-    */
+        */
   headerText!: string;
-
   /**
-     Determines on which side the component is placed at.
-    */
+        Determines on which side the component is placed at.
+        */
   placement!: 'Start' | 'End' | 'Top' | 'Bottom';
-
   /**
-     Determines the horizontal alignment of the component.
-    */
+        Determines the horizontal alignment of the component.
+        */
   horizontalAlign!: 'Center' | 'Start' | 'End' | 'Stretch';
-
   /**
-     Determines the vertical alignment of the component.
-    */
+        Determines the vertical alignment of the component.
+        */
   verticalAlign!: 'Center' | 'Top' | 'Bottom' | 'Stretch';
-
   /**
-     Defines whether the component should close when
+        Defines whether the component should close when
 clicking/tapping outside of the popover.
 If enabled, it blocks any interaction with the background.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   modal!: boolean;
-
   /**
-     Determines whether the component arrow is hidden.
-    */
+        Determines whether the component arrow is hidden.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideArrow!: boolean;
-
   /**
-     Determines if there is no enough space, the component can be placed
+        Determines if there is no enough space, the component can be placed
 over the target.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   allowTargetOverlap!: boolean;
-
   /**
-     Defines the ID or DOM Reference of the element at which the popover is shown.
+        Defines the ID or DOM Reference of the element at which the popover is shown.
 When using this attribute in a declarative way, you must only use the \`id\` (as a string) of the element at which you want to show the popover.
 You can only set the \`opener\` attribute to a DOM Reference when using JavaScript.
-    */
+        */
   opener!: HTMLElement | string | undefined;
 
   /**
@@ -5990,7 +5865,9 @@ exports[`Snapshot test Main Segmented Button Item should match the snapshot 1`] 
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -6020,41 +5897,38 @@ import SegmentedButtonItem from '@ui5/webcomponents/dist/SegmentedButtonItem.js'
 })
 class SegmentedButtonItemComponent {
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be selected or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines whether the component is displayed as selected.
-    */
+        Determines whether the component is displayed as selected.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 **Note:** A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the icon, displayed as graphical element within the component.
+        Defines the icon, displayed as graphical element within the component.
 The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
 
   private elementRef: ElementRef<SegmentedButtonItem> = inject(ElementRef);
@@ -6100,13 +5974,12 @@ import {
 })
 class SegmentedButtonComponent {
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Defines the component selection mode.
-    */
+        Defines the component selection mode.
+        */
   selectionMode!: 'Single' | 'Multiple';
 
   /**
@@ -6136,7 +6009,9 @@ exports[`Snapshot test Main Select should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -6184,49 +6059,45 @@ import {
 })
 class SelectComponent {
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the select.
-    */
+        Receives id(or many ids) of the elements that label the select.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the value of the component:
+        Defines the value of the component:
 
 - when get - returns the value of the component, e.g. the \`value\` property of the selected option or its text content.
 
@@ -6234,7 +6105,7 @@ but still provides visual feedback upon user interaction.
 
 **Note:** If the given value does not match any existing option,
 the first option will get selected.
-    */
+        */
   value!: string;
 
   /**
@@ -6287,7 +6158,9 @@ exports[`Snapshot test Main Slider should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -6333,63 +6206,57 @@ import Slider from '@ui5/webcomponents/dist/Slider.js';
 })
 class SliderComponent {
   /**
-     Defines the minimum value of the slider.
-    */
+        Defines the minimum value of the slider.
+        */
   min!: number;
-
   /**
-     Defines the maximum value of the slider.
-    */
+        Defines the maximum value of the slider.
+        */
   max!: number;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the size of the slider's selection intervals (e.g. min = 0, max = 10, step = 5 would result in possible selection of the values 0, 5, 10).
+        Defines the size of the slider's selection intervals (e.g. min = 0, max = 10, step = 5 would result in possible selection of the values 0, 5, 10).
 
 **Note:** If set to 0 the slider handle movement is disabled. When negative number or value other than a number, the component fallbacks to its default value.
-    */
+        */
   step!: number;
-
   /**
-     Displays a label with a value on every N-th step.
+        Displays a label with a value on every N-th step.
 
 **Note:** The step and tickmarks properties must be enabled.
 Example - if the step value is set to 2 and the label interval is also specified to 2 - then every second
 tickmark will be labelled, which means every 4th value number.
-    */
+        */
   labelInterval!: number;
-
   /**
-     Enables tickmarks visualization for each step.
+        Enables tickmarks visualization for each step.
 
 **Note:** The step must be a positive number.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showTickmarks!: boolean;
-
   /**
-     Enables handle tooltip displaying the current value.
-    */
+        Enables handle tooltip displaying the current value.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showTooltip!: boolean;
-
   /**
-     Defines whether the slider is in disabled state.
-    */
+        Defines whether the slider is in disabled state.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Current value of the slider
-    */
+        Current value of the slider
+        */
   value!: number;
 
   /**
@@ -6448,14 +6315,13 @@ import SpecialCalendarDate from '@ui5/webcomponents/dist/SpecialCalendarDate.js'
 })
 class SpecialCalendarDateComponent {
   /**
-     The date formatted according to the \`formatPattern\` property
+        The date formatted according to the \`formatPattern\` property
 of the \`ui5-calendar\` that hosts the component.
-    */
+        */
   value!: string;
-
   /**
-     Defines the type of the special date.
-    */
+        Defines the type of the special date.
+        */
   type!:
     | 'None'
     | 'Working'
@@ -6503,7 +6369,9 @@ exports[`Snapshot test Main Split Button should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -6527,23 +6395,22 @@ import SplitButton from '@ui5/webcomponents/dist/SplitButton.js';
 })
 class SplitButtonComponent {
   /**
-     Defines the icon to be displayed as graphical element within the component.
+        Defines the icon to be displayed as graphical element within the component.
 The SAP-icons font provides numerous options.
 
 Example:
 
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether the arrow button should have the active state styles or not.
-    */
+        Defines whether the arrow button should have the active state styles or not.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   activeArrowButton!: boolean;
-
   /**
-     Defines the component design.
-    */
+        Defines the component design.
+        */
   design!:
     | 'Default'
     | 'Positive'
@@ -6551,17 +6418,16 @@ See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-
     | 'Transparent'
     | 'Emphasized'
     | 'Attention';
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be pressed or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
 
   /**
@@ -6595,7 +6461,9 @@ exports[`Snapshot test Main Standard List Item should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -6644,21 +6512,20 @@ import StandardListItem from '@ui5/webcomponents/dist/StandardListItem.js';
 })
 class StandardListItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -6666,80 +6533,72 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines the description displayed right under the item text, if such is present.
-    */
+        Defines the description displayed right under the item text, if such is present.
+        */
   description!: string;
-
   /**
-     Defines the \`icon\` source URI.
+        Defines the \`icon\` source URI.
 
 **Note:**
 SAP-icons font provides numerous built-in icons. To find all the available icons, see the
 [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether the \`icon\` should be displayed in the beginning of the list item or in the end.
+        Defines whether the \`icon\` should be displayed in the beginning of the list item or in the end.
 
 **Note:** If \`image\` is set, the \`icon\` would be displayed after the \`image\`.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   iconEnd!: boolean;
-
   /**
-     Defines the \`image\` source URI.
+        Defines the \`image\` source URI.
 
 **Note:** The \`image\` would be displayed in the beginning of the list item.
-    */
+        */
   image!: string;
-
   /**
-     Defines the \`additionalText\`, displayed in the end of the list item.
-    */
+        Defines the \`additionalText\`, displayed in the end of the list item.
+        */
   additionalText!: string;
-
   /**
-     Defines the state of the \`additionalText\`.
+        Defines the state of the \`additionalText\`.
 
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   additionalTextState!:
     | 'None'
     | 'Positive'
     | 'Critical'
     | 'Negative'
     | 'Information';
-
   /**
-     Defines whether the item is movable.
-    */
+        Defines whether the item is movable.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   movable!: boolean;
-
   /**
-     Defines the text alternative of the component.
+        Defines the text alternative of the component.
 Note: If not provided a default text alternative will be set, if present.
-    */
+        */
   accessibleName!: string;
 
   /**
@@ -6769,7 +6628,9 @@ exports[`Snapshot test Main Step Input should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -6818,74 +6679,65 @@ import {
 })
 class StepInputComponent {
   /**
-     Defines a value of the component.
-    */
+        Defines a value of the component.
+        */
   value!: number;
-
   /**
-     Defines a minimum value of the component.
-    */
+        Defines a minimum value of the component.
+        */
   min!: number | undefined;
-
   /**
-     Defines a maximum value of the component.
-    */
+        Defines a maximum value of the component.
+        */
   max!: number | undefined;
-
   /**
-     Defines a step of increasing/decreasing the value of the component.
-    */
+        Defines a step of increasing/decreasing the value of the component.
+        */
   step!: number;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Determines whether the component is displayed as disabled.
-    */
+        Determines whether the component is displayed as disabled.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Determines whether the component is displayed as read-only.
-    */
+        Determines whether the component is displayed as read-only.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines a short hint, intended to aid the user with data entry when the
+        Defines a short hint, intended to aid the user with data entry when the
 component has no value.
 
 **Note:** When no placeholder is set, the format pattern is displayed as a placeholder.
 Passing an empty string as the value of this property will make the component appear empty - without placeholder or format pattern.
-    */
+        */
   placeholder!: string | undefined;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Determines the number of digits after the decimal point of the component.
-    */
+        Determines the number of digits after the decimal point of the component.
+        */
   valuePrecision!: number;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -6936,8 +6788,8 @@ import SuggestionGroupItem from '@ui5/webcomponents/dist/SuggestionGroupItem.js'
 })
 class SuggestionGroupItemComponent {
   /**
-     Defines the text of the \`ui5-suggestion-group-item\`.
-    */
+        Defines the text of the \`ui5-suggestion-group-item\`.
+        */
   text!: string;
 
   private elementRef: ElementRef<SuggestionGroupItem> = inject(ElementRef);
@@ -6961,7 +6813,9 @@ exports[`Snapshot test Main Suggestion Item should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -6995,55 +6849,49 @@ import SuggestionItem from '@ui5/webcomponents/dist/SuggestionItem.js';
 })
 class SuggestionItemComponent {
   /**
-     Defines the text of the component.
-    */
+        Defines the text of the component.
+        */
   text!: string;
-
   /**
-     Defines the visual indication and behavior of the item.
+        Defines the visual indication and behavior of the item.
 Available options are \`Active\` (by default), \`Inactive\` and \`Detail\`.
 
 **Note:** When set to \`Active\`, the item will provide visual response upon press and hover,
 while when \`Inactive\` or \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the description displayed right under the item text, if such is present.
-    */
+        Defines the description displayed right under the item text, if such is present.
+        */
   description!: string;
-
   /**
-     Defines the \`icon\` source URI.
+        Defines the \`icon\` source URI.
 
 **Note:**
 SAP-icons font provides numerous built-in icons. To find all the available icons, see the
 [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines whether the \`icon\` should be displayed in the beginning of the item or in the end.
+        Defines whether the \`icon\` should be displayed in the beginning of the item or in the end.
 
 **Note:** If \`image\` is set, the \`icon\` would be displayed after the \`image\`.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   iconEnd!: boolean;
-
   /**
-     Defines the \`image\` source URI.
+        Defines the \`image\` source URI.
 
 **Note:** The \`image\` would be displayed in the beginning of the item.
-    */
+        */
   image!: string;
-
   /**
-     Defines the \`additionalText\`, displayed in the end of the item.
-    */
+        Defines the \`additionalText\`, displayed in the end of the item.
+        */
   additionalText!: string;
-
   /**
-     Defines the state of the \`additionalText\`.
-    */
+        Defines the state of the \`additionalText\`.
+        */
   additionalTextState!:
     | 'None'
     | 'Positive'
@@ -7073,7 +6921,9 @@ exports[`Snapshot test Main Switch should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -7116,75 +6966,69 @@ import Switch from '@ui5/webcomponents/dist/Switch.js';
 })
 class SwitchComponent {
   /**
-     Defines the component design.
+        Defines the component design.
 
 **Note:** If \`Graphical\` type is set,
 positive and negative icons will replace the \`textOn\` and \`textOff\`.
-    */
+        */
   design!: 'Textual' | 'Graphical';
-
   /**
-     Defines if the component is checked.
+        Defines if the component is checked.
 
 **Note:** The property can be changed with user interaction,
 either by cliking the component, or by pressing the \`Enter\` or \`Space\` key.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   checked!: boolean;
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** A disabled component is noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the text, displayed when the component is checked.
+        Defines the text, displayed when the component is checked.
 
 **Note:** We recommend using short texts, up to 3 letters (larger texts would be cut off).
-    */
+        */
   textOn!: string;
-
   /**
-     Defines the text, displayed when the component is not checked.
+        Defines the text, displayed when the component is not checked.
 
 **Note:** We recommend using short texts, up to 3 letters (larger texts would be cut off).
-    */
+        */
   textOff!: string;
-
   /**
-     Sets the accessible ARIA name of the component.
+        Sets the accessible ARIA name of the component.
 
 **Note**: We recommend that you set an accessibleNameRef pointing to an external label or at least an \`accessibleName\`.
 Providing an \`accessibleNameRef\` or an \`accessibleName\` is mandatory in the cases when \`textOn\` and \`textOff\` properties aren't set.
-    */
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
+        Receives id(or many ids) of the elements that label the component.
 
 **Note**: We recommend that you set an accessibleNameRef pointing to an external label or at least an \`accessibleName\`.
 Providing an \`accessibleNameRef\` or an \`accessibleName\` is mandatory in the cases when \`textOn\` and \`textOff\` properties aren't set.
-    */
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 **Note:** If applicable an external label reference should always be the preferred option to provide context to the \`ui5-switch\` component over a tooltip.
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
 
   /**
@@ -7224,7 +7068,9 @@ exports[`Snapshot test Main Tab Container should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -7262,37 +7108,34 @@ import {
 })
 class TabContainerComponent {
   /**
-     Defines whether the tab content is collapsed.
-    */
+        Defines whether the tab content is collapsed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   collapsed!: boolean;
-
   /**
-     Defines the alignment of the content and the \`additionalText\` of a tab.
+        Defines the alignment of the content and the \`additionalText\` of a tab.
 
 **Note:**
 The content and the \`additionalText\` would be displayed vertically by default,
 but when set to \`Inline\`, they would be displayed horizontally.
-    */
+        */
   tabLayout!: 'Inline' | 'Standard';
-
   /**
-     Defines the overflow mode of the header (the tab strip). If you have a large number of tabs, only the tabs that can fit on screen will be visible.
+        Defines the overflow mode of the header (the tab strip). If you have a large number of tabs, only the tabs that can fit on screen will be visible.
 All other tabs that can 't fit on the screen are available in an overflow tab \\"More\\".
 
 **Note:**
 Only one overflow at the end would be displayed by default,
 but when set to \`StartAndEnd\`, there will be two overflows on both ends, and tab order will not change on tab selection.
-    */
+        */
   overflowMode!: 'End' | 'StartAndEnd';
-
   /**
-     Sets the background color of the Tab Container's header as \`Solid\`, \`Transparent\`, or \`Translucent\`.
-    */
+        Sets the background color of the Tab Container's header as \`Solid\`, \`Transparent\`, or \`Translucent\`.
+        */
   headerBackgroundDesign!: 'Solid' | 'Transparent' | 'Translucent';
-
   /**
-     Sets the background color of the Tab Container's content as \`Solid\`, \`Transparent\`, or \`Translucent\`.
-    */
+        Sets the background color of the Tab Container's content as \`Solid\`, \`Transparent\`, or \`Translucent\`.
+        */
   contentBackgroundDesign!: 'Solid' | 'Transparent' | 'Translucent';
 
   /**
@@ -7367,7 +7210,9 @@ exports[`Snapshot test Main Tab should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -7390,29 +7235,26 @@ import Tab from '@ui5/webcomponents/dist/Tab.js';
 })
 class TabComponent {
   /**
-     The text to be displayed for the item.
-    */
+        The text to be displayed for the item.
+        */
   text!: string;
-
   /**
-     Disabled tabs can't be selected.
-    */
+        Disabled tabs can't be selected.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Represents the \\"additionalText\\" text, which is displayed in the tab. In the cases when in the same time there are tabs with icons and tabs without icons, if a tab has no icon the \\"additionalText\\" is displayed larger.
-    */
+        Represents the \\"additionalText\\" text, which is displayed in the tab. In the cases when in the same time there are tabs with icons and tabs without icons, if a tab has no icon the \\"additionalText\\" is displayed larger.
+        */
   additionalText!: string;
-
   /**
-     Defines the icon source URI to be displayed as graphical element within the component.
+        Defines the icon source URI to be displayed as graphical element within the component.
 The SAP-icons font provides numerous built-in icons.
 See all the available icons in the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the component's design color.
+        Defines the component's design color.
 
 The design is applied to:
 
@@ -7423,12 +7265,12 @@ The design is applied to:
 Available designs are: \`\\"Default\\"\`, \`\\"Neutral\\"\`, \`\\"Positive\\"\`, \`\\"Critical\\"\` and \`\\"Negative\\"\`.
 
 **Note:** The design depends on the current theme.
-    */
+        */
   design!: 'Default' | 'Positive' | 'Negative' | 'Critical' | 'Neutral';
-
   /**
-     Specifies if the component is selected.
-    */
+        Specifies if the component is selected.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<Tab> = inject(ElementRef);
@@ -7453,7 +7295,9 @@ exports[`Snapshot test Main Tag should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -7485,8 +7329,8 @@ import Tag from '@ui5/webcomponents/dist/Tag.js';
 })
 class TagComponent {
   /**
-     Defines the design type of the component.
-    */
+        Defines the design type of the component.
+        */
   design!:
     | 'Set1'
     | 'Set2'
@@ -7496,38 +7340,35 @@ class TagComponent {
     | 'Positive'
     | 'Negative'
     | 'Critical';
-
   /**
-     Defines the color scheme of the component.
+        Defines the color scheme of the component.
 There are 10 predefined schemes.
 To use one you can set a number from \`\\"1\\"\` to \`\\"10\\"\`. The \`colorScheme\` \`\\"1\\"\` will be set by default.
-    */
+        */
   colorScheme!: string;
-
   /**
-     Defines if the default state icon is shown.
-    */
+        Defines if the default state icon is shown.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideStateIcon!: boolean;
-
   /**
-     Defines if the component is interactive (focusable and pressable).
+        Defines if the component is interactive (focusable and pressable).
 
 **Note:** The tag cannot be \`interactive\`
 when \`design\` property is \`TagDesign.Set3\`
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   interactive!: boolean;
-
   /**
-     Defines how the text of a component will be displayed when there is not enough space.
+        Defines how the text of a component will be displayed when there is not enough space.
 
 **Note:** For option \\"Normal\\" the text will wrap and the
 words will not be broken based on hyphenation.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Defines predefined size of the component.
-    */
+        Defines predefined size of the component.
+        */
   size!: 'S' | 'L';
 
   /**
@@ -7559,7 +7400,9 @@ exports[`Snapshot test Main Text Area should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -7618,96 +7461,88 @@ import TextArea from '@ui5/webcomponents/dist/TextArea.js';
 })
 class TextAreaComponent {
   /**
-     Defines the value of the component.
-    */
+        Defines the value of the component.
+        */
   value!: string;
-
   /**
-     Indicates whether the user can interact with the component or not.
+        Indicates whether the user can interact with the component or not.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is required.
-    */
+        Defines whether the component is required.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   required!: boolean;
-
   /**
-     Defines a short hint intended to aid the user with data entry when the component has no value.
-    */
+        Defines a short hint intended to aid the user with data entry when the component has no value.
+        */
   placeholder!: string;
-
   /**
-     Defines the value state of the component.
+        Defines the value state of the component.
 
 **Note:** If \`maxlength\` property is set,
 the component turns into \\"Warning\\" state once the characters exceeds the limit.
 In this case, only the \\"Error\\" state is considered and can be applied.
-    */
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines the number of visible text rows for the component.
+        Defines the number of visible text rows for the component.
 
 **Notes:**
 
 - If the \`growing\` property is enabled, this property defines the minimum rows to be displayed
 in the textarea.
 - The CSS \`height\` property wins over the \`rows\` property, if both are set.
-    */
+        */
   rows!: number;
-
   /**
-     Defines the maximum number of characters that the \`value\` can have.
-    */
+        Defines the maximum number of characters that the \`value\` can have.
+        */
   maxlength!: number | undefined;
-
   /**
-     Determines whether the characters exceeding the maximum allowed character count are visible
+        Determines whether the characters exceeding the maximum allowed character count are visible
 in the component.
 
 If set to \`false\`, the user is not allowed to enter more characters than what is set in the
 \`maxlength\` property.
 If set to \`true\` the characters exceeding the \`maxlength\` value are selected on
 paste and the counter below the component displays their number.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   showExceededText!: boolean;
-
   /**
-     Enables the component to automatically grow and shrink dynamically with its content.
-    */
+        Enables the component to automatically grow and shrink dynamically with its content.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   growing!: boolean;
-
   /**
-     Defines the maximum number of rows that the component can grow.
-    */
+        Defines the maximum number of rows that the component can grow.
+        */
   growingMaxRows!: number;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the textarea.
-    */
+        Receives id(or many ids) of the elements that label the textarea.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -7775,8 +7610,8 @@ import Text from '@ui5/webcomponents/dist/Text.js';
 })
 class TextComponent {
   /**
-     Defines the number of lines the text should wrap before it truncates.
-    */
+        Defines the number of lines the text should wrap before it truncates.
+        */
   maxLines!: number;
 
   private elementRef: ElementRef<Text> = inject(ElementRef);
@@ -7819,7 +7654,9 @@ exports[`Snapshot test Main Time Picker should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { GenericControlValueAccessor } from '@ui5/webcomponents-ngx/generic-cva';
@@ -7870,54 +7707,50 @@ import {
 })
 class TimePickerComponent {
   /**
-     Defines a formatted time value.
-    */
+        Defines a formatted time value.
+        */
   value!: string | undefined;
-
   /**
-     Determines the name by which the component will be identified upon submission in an HTML form.
+        Determines the name by which the component will be identified upon submission in an HTML form.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   name!: string;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines the disabled state of the comonent.
-    */
+        Defines the disabled state of the comonent.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the readonly state of the comonent.
-    */
+        Defines the readonly state of the comonent.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines a short hint, intended to aid the user with data entry when the
+        Defines a short hint, intended to aid the user with data entry when the
 component has no value.
 
 **Note:** When no placeholder is set, the format pattern is displayed as a placeholder.
 Passing an empty string as the value of this property will make the component appear empty - without placeholder or format pattern.
-    */
+        */
   placeholder!: string | undefined;
-
   /**
-     Determines the format, displayed in the input field.
+        Determines the format, displayed in the input field.
 
 Example:
 HH:mm:ss -> 11:42:35
 hh:mm:ss a -> 2:23:15 PM
 mm:ss -> 12:04 (only minutes and seconds)
-    */
+        */
   formatPattern!: string;
-
   /**
-     Defines the open or closed state of the popover.
-    */
+        Defines the open or closed state of the popover.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
 
   /**
@@ -7985,16 +7818,15 @@ import Title from '@ui5/webcomponents/dist/Title.js';
 })
 class TitleComponent {
   /**
-     Defines how the text of a component will be displayed when there is not enough space.
+        Defines how the text of a component will be displayed when there is not enough space.
 
 **Note:** for option \\"Normal\\" the text will wrap and the words will not be broken based on hyphenation.
-    */
+        */
   wrappingType!: 'None' | 'Normal';
-
   /**
-     Defines the component level.
+        Defines the component level.
 Available options are: \`\\"H6\\"\` to \`\\"H1\\"\`.
-    */
+        */
   level!: 'H1' | 'H2' | 'H3' | 'H4' | 'H5' | 'H6';
 
   private elementRef: ElementRef<Title> = inject(ElementRef);
@@ -8019,7 +7851,9 @@ exports[`Snapshot test Main Toast should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8037,17 +7871,16 @@ import Toast from '@ui5/webcomponents/dist/Toast.js';
 })
 class ToastComponent {
   /**
-     Defines the duration in milliseconds for which component
+        Defines the duration in milliseconds for which component
 remains on the screen before it's automatically closed.
 
 **Note:** The minimum supported value is \`500\` ms
 and even if a lower value is set, the duration would remain \`500\` ms.
-    */
+        */
   duration!: number;
-
   /**
-     Defines the placement of the component.
-    */
+        Defines the placement of the component.
+        */
   placement!:
     | 'TopStart'
     | 'TopCenter'
@@ -8058,10 +7891,10 @@ and even if a lower value is set, the duration would remain \`500\` ms.
     | 'BottomStart'
     | 'BottomCenter'
     | 'BottomEnd';
-
   /**
-     Indicates whether the component is open (visible).
-    */
+        Indicates whether the component is open (visible).
+        */
+  @InputDecorator({ transform: booleanAttribute })
   open!: boolean;
 
   /**
@@ -8091,7 +7924,9 @@ exports[`Snapshot test Main Toggle Button should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8136,8 +7971,8 @@ import ToggleButton from '@ui5/webcomponents/dist/ToggleButton.js';
 })
 class ToggleButtonComponent {
   /**
-     Defines the component design.
-    */
+        Defines the component design.
+        */
   design!:
     | 'Default'
     | 'Positive'
@@ -8145,25 +7980,23 @@ class ToggleButtonComponent {
     | 'Transparent'
     | 'Emphasized'
     | 'Attention';
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 A disabled component can't be pressed or
 focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the icon, displayed as graphical element within the component.
+        Defines the icon, displayed as graphical element within the component.
 The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the icon, displayed as graphical element within the component after the button text.
+        Defines the icon, displayed as graphical element within the component after the button text.
 
 **Note:** It is highly recommended to use \`endIcon\` property only together with \`icon\` and/or \`text\` properties.
 Usage of \`endIcon\` only should be avoided.
@@ -8172,36 +8005,32 @@ The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   endIcon!: string;
-
   /**
-     When set to \`true\`, the component will
+        When set to \`true\`, the component will
 automatically submit the nearest HTML form element on \`press\`.
 
 **Note:** This property is only applicable within the context of an HTML Form element.\`
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   submits!: boolean;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 **Note:** A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **expanded**: Indicates whether the button, or another grouping element it controls, is currently expanded or collapsed.
@@ -8212,26 +8041,24 @@ Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\`
 
 - **controls**: Identifies the element (or elements) whose contents or presence are controlled by the button element.
 Accepts a lowercase string value.
-    */
+        */
   accessibilityAttributes!: ButtonAccessibilityAttributes;
-
   /**
-     Defines whether the button has special form-related functionality.
+        Defines whether the button has special form-related functionality.
 
 **Note:** This property is only applicable within the context of an HTML Form element.
-    */
+        */
   type!: 'Button' | 'Submit' | 'Reset';
-
   /**
-     Describes the accessibility role of the button.
+        Describes the accessibility role of the button.
 
 **Note:** Use <code>ButtonAccessibleRole.Link</code> role only with a press handler, which performs a navigation. In all other scenarios the default button semantics are recommended.
-    */
+        */
   accessibleRole!: 'Button' | 'Link';
-
   /**
-     Determines whether the component is displayed as pressed.
-    */
+        Determines whether the component is displayed as pressed.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   pressed!: boolean;
 
   /**
@@ -8264,7 +8091,9 @@ exports[`Snapshot test Main Token should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -8280,13 +8109,13 @@ import Token from '@ui5/webcomponents/dist/Token.js';
 })
 class TokenComponent {
   /**
-     Defines the text of the token.
-    */
+        Defines the text of the token.
+        */
   text!: string;
-
   /**
-     Defines whether the component is selected or not.
-    */
+        Defines whether the component is selected or not.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<Token> = inject(ElementRef);
@@ -8311,7 +8140,9 @@ exports[`Snapshot test Main Tokenizer should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8336,28 +8167,27 @@ import {
 })
 class TokenizerComponent {
   /**
-     Defines whether the component is read-only.
+        Defines whether the component is read-only.
 
 **Note:** A read-only component is not editable,
 but still provides visual feedback upon user interaction.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   readonly!: boolean;
-
   /**
-     Defines whether the component is disabled.
+        Defines whether the component is disabled.
 
 **Note:** A disabled component is completely noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string | undefined;
 
   /**
@@ -8391,7 +8221,9 @@ exports[`Snapshot test Main Toolbar Button should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8438,27 +8270,26 @@ import {
 })
 class ToolbarButtonComponent {
   /**
-     Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
+        Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
 the item never goes in the Popover, if \\"AlwaysOverflow\\" - it never comes out of it.
-    */
+        */
   overflowPriority!: 'Default' | 'NeverOverflow' | 'AlwaysOverflow';
-
   /**
-     Defines if the toolbar overflow popup should close upon intereaction with the item.
+        Defines if the toolbar overflow popup should close upon intereaction with the item.
 It will close by default.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventOverflowClosing!: boolean;
-
   /**
-     Defines if the action is disabled.
+        Defines if the action is disabled.
 
 **Note:** a disabled action can't be pressed or focused, and it is not in the tab chain.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the action design.
-    */
+        Defines the action design.
+        */
   design!:
     | 'Default'
     | 'Positive'
@@ -8466,17 +8297,15 @@ It will close by default.
     | 'Transparent'
     | 'Emphasized'
     | 'Attention';
-
   /**
-     Defines the \`icon\` source URI.
+        Defines the \`icon\` source URI.
 
 **Note:** SAP-icons font provides numerous buil-in icons. To find all the available icons, see the
 [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   icon!: string;
-
   /**
-     Defines the icon, displayed as graphical element within the component after the button text.
+        Defines the icon, displayed as graphical element within the component after the button text.
 
 **Note:** It is highly recommended to use \`endIcon\` property only together with \`icon\` and/or \`text\` properties.
 Usage of \`endIcon\` only should be avoided.
@@ -8485,28 +8314,24 @@ The SAP-icons font provides numerous options.
 
 Example:
 See all the available icons within the [Icon Explorer](https://sdk.openui5.org/test-resources/sap/m/demokit/iconExplorer/webapp/index.html).
-    */
+        */
   endIcon!: string;
-
   /**
-     Defines the tooltip of the component.
+        Defines the tooltip of the component.
 
 **Note:** A tooltip attribute should be provided for icon-only buttons, in order to represent their exact meaning/function.
-    */
+        */
   tooltip!: string;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string | undefined;
-
   /**
-     Receives id(or many ids) of the elements that label the component.
-    */
+        Receives id(or many ids) of the elements that label the component.
+        */
   accessibleNameRef!: string;
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 
 The following fields are supported:
 
@@ -8518,19 +8343,17 @@ Accepts the following string values: \`dialog\`, \`grid\`, \`listbox\`, \`menu\`
 
 - **controls**: Identifies the element (or elements) whose contents or presence are controlled by the button element.
 Accepts a lowercase string value.
-    */
+        */
   accessibilityAttributes!: ToolbarAccessibilityAttributes;
-
   /**
-     Button text
-    */
+        Button text
+        */
   text!: string;
-
   /**
-     Defines the width of the button.
+        Defines the width of the button.
 
 **Note:** all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
-    */
+        */
   width!: string | undefined;
 
   /**
@@ -8563,7 +8386,9 @@ exports[`Snapshot test Main Toolbar Select Option should match the snapshot 1`] 
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -8579,8 +8404,9 @@ import ToolbarSelectOption from '@ui5/webcomponents/dist/ToolbarSelectOption.js'
 })
 class ToolbarSelectOptionComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
 
   private elementRef: ElementRef<ToolbarSelectOption> = inject(ElementRef);
@@ -8605,7 +8431,9 @@ exports[`Snapshot test Main Toolbar Select should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8642,44 +8470,40 @@ import {
 })
 class ToolbarSelectComponent {
   /**
-     Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
+        Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
 the item never goes in the Popover, if \\"AlwaysOverflow\\" - it never comes out of it.
-    */
+        */
   overflowPriority!: 'Default' | 'NeverOverflow' | 'AlwaysOverflow';
-
   /**
-     Defines if the toolbar overflow popup should close upon intereaction with the item.
+        Defines if the toolbar overflow popup should close upon intereaction with the item.
 It will close by default.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventOverflowClosing!: boolean;
-
   /**
-     Defines the width of the select.
+        Defines the width of the select.
 
 **Note:** all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
-    */
+        */
   width!: string | undefined;
-
   /**
-     Defines the value state of the component.
-    */
+        Defines the value state of the component.
+        */
   valueState!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     Defines whether the component is in disabled state.
+        Defines whether the component is in disabled state.
 
 **Note:** A disabled component is noninteractive.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   disabled!: boolean;
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the select.
-    */
+        Receives id(or many ids) of the elements that label the select.
+        */
   accessibleNameRef!: string;
 
   /**
@@ -8716,7 +8540,9 @@ exports[`Snapshot test Main Toolbar Separator should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -8732,15 +8558,15 @@ import ToolbarSeparator from '@ui5/webcomponents/dist/ToolbarSeparator.js';
 })
 class ToolbarSeparatorComponent {
   /**
-     Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
+        Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
 the item never goes in the Popover, if \\"AlwaysOverflow\\" - it never comes out of it.
-    */
+        */
   overflowPriority!: 'Default' | 'NeverOverflow' | 'AlwaysOverflow';
-
   /**
-     Defines if the toolbar overflow popup should close upon intereaction with the item.
+        Defines if the toolbar overflow popup should close upon intereaction with the item.
 It will close by default.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventOverflowClosing!: boolean;
 
   private elementRef: ElementRef<ToolbarSeparator> = inject(ElementRef);
@@ -8764,7 +8590,9 @@ exports[`Snapshot test Main Toolbar Spacer should match the snapshot 1`] = `
   ChangeDetectorRef,
   Component,
   ElementRef,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs } from '@ui5/webcomponents-ngx/utils';
@@ -8780,22 +8608,21 @@ import ToolbarSpacer from '@ui5/webcomponents/dist/ToolbarSpacer.js';
 })
 class ToolbarSpacerComponent {
   /**
-     Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
+        Property used to define the access of the item to the overflow Popover. If \\"NeverOverflow\\" option is set,
 the item never goes in the Popover, if \\"AlwaysOverflow\\" - it never comes out of it.
-    */
+        */
   overflowPriority!: 'Default' | 'NeverOverflow' | 'AlwaysOverflow';
-
   /**
-     Defines if the toolbar overflow popup should close upon intereaction with the item.
+        Defines if the toolbar overflow popup should close upon intereaction with the item.
 It will close by default.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   preventOverflowClosing!: boolean;
-
   /**
-     Defines the width of the spacer.
+        Defines the width of the spacer.
 
 **Note:** all CSS sizes are supported - 'percentage', 'px', 'rem', 'auto', etc.
-    */
+        */
   width!: string | undefined;
 
   private elementRef: ElementRef<ToolbarSpacer> = inject(ElementRef);
@@ -8835,18 +8662,16 @@ import Toolbar from '@ui5/webcomponents/dist/Toolbar.js';
 })
 class ToolbarComponent {
   /**
-     Indicated the direction in which the Toolbar items will be aligned.
-    */
+        Indicated the direction in which the Toolbar items will be aligned.
+        */
   alignContent!: 'Start' | 'End';
-
   /**
-     Defines the accessible ARIA name of the component.
-    */
+        Defines the accessible ARIA name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Receives id(or many ids) of the elements that label the input.
-    */
+        Receives id(or many ids) of the elements that label the input.
+        */
   accessibleNameRef!: string;
 
   private elementRef: ElementRef<Toolbar> = inject(ElementRef);
@@ -8871,7 +8696,9 @@ exports[`Snapshot test Main Tree Item Custom should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -8920,21 +8747,20 @@ import TreeItemCustom from '@ui5/webcomponents/dist/TreeItemCustom.js';
 })
 class TreeItemCustomComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -8942,43 +8768,39 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     If set, an icon will be displayed before the text of the tree list item.
-    */
+        If set, an icon will be displayed before the text of the tree list item.
+        */
   icon!: string;
-
   /**
-     Defines whether the tree list item will show a collapse or expand icon inside its toggle button.
-    */
+        Defines whether the tree list item will show a collapse or expand icon inside its toggle button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   expanded!: boolean;
-
   /**
-     Defines whether the item is movable.
-    */
+        Defines whether the item is movable.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   movable!: boolean;
-
   /**
-     Defines whether the selection of a tree node is displayed as partially selected.
+        Defines whether the selection of a tree node is displayed as partially selected.
 
 **Note:** The indeterminate state can be set only programmatically and can’t be achieved by user
 interaction, meaning that the resulting visual state depends on the values of the \`indeterminate\`
@@ -8989,38 +8811,37 @@ and \`selected\` properties:
 -  If a tree node has \`selected\` set to \`false\`, it is displayed as not selected regardless of the value of the \`indeterminate\` property.
 
 **Note:** This property takes effect only when the \`ui5-tree\` is in \`Multiple\` mode.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   indeterminate!: boolean;
-
   /**
-     Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
+        Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
 
 **Note:** This property is useful for showing big tree structures where not all nodes are initially loaded due to performance reasons.
 Set this to \`true\` for nodes you intend to load lazily, when the user clicks the expand button.
 It is not necessary to set this property otherwise. If a tree item has children, the expand button will be displayed anyway.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hasChildren!: boolean;
-
   /**
-     Defines the state of the \`additionalText\`.
+        Defines the state of the \`additionalText\`.
 
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   additionalTextState!:
     | 'None'
     | 'Positive'
     | 'Critical'
     | 'Negative'
     | 'Information';
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines whether the tree list item should display the selection element.
-    */
+        Defines whether the tree list item should display the selection element.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hideSelectionElement!: boolean;
 
   /**
@@ -9050,7 +8871,9 @@ exports[`Snapshot test Main Tree Item should match the snapshot 1`] = `
   Component,
   ElementRef,
   EventEmitter,
+  Input as InputDecorator,
   NgZone,
+  booleanAttribute,
   inject,
 } from '@angular/core';
 import { ProxyInputs, ProxyOutputs } from '@ui5/webcomponents-ngx/utils';
@@ -9101,21 +8924,20 @@ import TreeItem from '@ui5/webcomponents/dist/TreeItem.js';
 })
 class TreeItemComponent {
   /**
-     Defines the selected state of the component.
-    */
+        Defines the selected state of the component.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   selected!: boolean;
-
   /**
-     Defines the visual indication and behavior of the list items.
+        Defines the visual indication and behavior of the list items.
 Available options are \`Active\` (by default), \`Inactive\`, \`Detail\` and \`Navigation\`.
 
 **Note:** When set to \`Active\` or \`Navigation\`, the item will provide visual response upon press and hover,
 while with type \`Inactive\` and \`Detail\` - will not.
-    */
+        */
   type!: 'Inactive' | 'Active' | 'Detail' | 'Navigation';
-
   /**
-     Defines the additional accessibility attributes that will be applied to the component.
+        Defines the additional accessibility attributes that will be applied to the component.
 The following fields are supported:
 
 - **ariaSetsize**: Defines the number of items in the current set  when not all items in the set are present in the DOM.
@@ -9123,43 +8945,39 @@ The following fields are supported:
 
 	- **ariaPosinset**: Defines an element's number or position in the current set when not all items are present in the DOM.
 	**Note:** The value is an integer greater than or equal to 1, and less than or equal to the size of the set when that size is known.
-    */
+        */
   accessibilityAttributes!: ListItemAccessibilityAttributes;
-
   /**
-     The navigated state of the list item.
+        The navigated state of the list item.
 If set to \`true\`, a navigation indicator is displayed at the end of the list item.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   navigated!: boolean;
-
   /**
-     Defines the text of the tooltip that would be displayed for the list item.
-    */
+        Defines the text of the tooltip that would be displayed for the list item.
+        */
   tooltip!: string;
-
   /**
-     Defines the highlight state of the list items.
+        Defines the highlight state of the list items.
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   highlight!: 'None' | 'Positive' | 'Critical' | 'Negative' | 'Information';
-
   /**
-     If set, an icon will be displayed before the text of the tree list item.
-    */
+        If set, an icon will be displayed before the text of the tree list item.
+        */
   icon!: string;
-
   /**
-     Defines whether the tree list item will show a collapse or expand icon inside its toggle button.
-    */
+        Defines whether the tree list item will show a collapse or expand icon inside its toggle button.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   expanded!: boolean;
-
   /**
-     Defines whether the item is movable.
-    */
+        Defines whether the item is movable.
+        */
+  @InputDecorator({ transform: booleanAttribute })
   movable!: boolean;
-
   /**
-     Defines whether the selection of a tree node is displayed as partially selected.
+        Defines whether the selection of a tree node is displayed as partially selected.
 
 **Note:** The indeterminate state can be set only programmatically and can’t be achieved by user
 interaction, meaning that the resulting visual state depends on the values of the \`indeterminate\`
@@ -9170,43 +8988,40 @@ and \`selected\` properties:
 -  If a tree node has \`selected\` set to \`false\`, it is displayed as not selected regardless of the value of the \`indeterminate\` property.
 
 **Note:** This property takes effect only when the \`ui5-tree\` is in \`Multiple\` mode.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   indeterminate!: boolean;
-
   /**
-     Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
+        Defines whether the tree node has children, even if currently no other tree nodes are slotted inside.
 
 **Note:** This property is useful for showing big tree structures where not all nodes are initially loaded due to performance reasons.
 Set this to \`true\` for nodes you intend to load lazily, when the user clicks the expand button.
 It is not necessary to set this property otherwise. If a tree item has children, the expand button will be displayed anyway.
-    */
+        */
+  @InputDecorator({ transform: booleanAttribute })
   hasChildren!: boolean;
-
   /**
-     Defines the state of the \`additionalText\`.
+        Defines the state of the \`additionalText\`.
 
 Available options are: \`\\"None\\"\` (by default), \`\\"Positive\\"\`, \`\\"Critical\\"\`, \`\\"Information\\"\` and \`\\"Negative\\"\`.
-    */
+        */
   additionalTextState!:
     | 'None'
     | 'Positive'
     | 'Critical'
     | 'Negative'
     | 'Information';
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines the text of the tree item.
-    */
+        Defines the text of the tree item.
+        */
   text!: string;
-
   /**
-     Defines the \`additionalText\`, displayed in the end of the tree item.
-    */
+        Defines the \`additionalText\`, displayed in the end of the tree item.
+        */
   additionalText!: string;
 
   /**
@@ -9290,9 +9105,9 @@ import {
 })
 class TreeComponent {
   /**
-     Defines the selection mode of the component. Since the tree uses a \`ui5-list\` to display its structure,
+        Defines the selection mode of the component. Since the tree uses a \`ui5-list\` to display its structure,
 the tree modes are exactly the same as the list modes, and are all applicable.
-    */
+        */
   selectionMode!:
     | 'None'
     | 'Single'
@@ -9301,32 +9116,27 @@ the tree modes are exactly the same as the list modes, and are all applicable.
     | 'SingleAuto'
     | 'Multiple'
     | 'Delete';
-
   /**
-     Defines the text that is displayed when the component contains no items.
-    */
+        Defines the text that is displayed when the component contains no items.
+        */
   noDataText!: string;
-
   /**
-     Defines the component header text.
+        Defines the component header text.
 
 **Note:** If the \`header\` slot is set, this property is ignored.
-    */
+        */
   headerText!: string;
-
   /**
-     Defines the component footer text.
-    */
+        Defines the component footer text.
+        */
   footerText!: string;
-
   /**
-     Defines the accessible name of the component.
-    */
+        Defines the accessible name of the component.
+        */
   accessibleName!: string;
-
   /**
-     Defines the IDs of the elements that label the component.
-    */
+        Defines the IDs of the elements that label the component.
+        */
   accessibleNameRef!: string;
 
   /**


### PR DESCRIPTION
**Summary**

The PR changes the angular component/wrapper/directive generation so that all boolean properties are declared with the `@Input({ transform: booleanAttribute }) ` to enable setting boolean attributes.

Previously, the only way to set boolean attributes used to be via the property syntax:
```html
<ui5-checkbox [disabled]="true"></ui5-checkbox>
```

While now, the same can be done with a simple attribute:

```html
<ui5-checkbox disabled></ui5-checkbox>
```


**How it works**

Generating all boolean properties (known as inputs in the Angular terminology) 
with `@Input({ transform: booleanAttribute }) `.

Previously
```ts
@Component({
  selector: 'ui5-checkbox',
})
export class CheckboxComponent {
  disabled!: boolean;
}
```

```html
  <!-- Wasn't working before -->
<ui5-checkbox disabled></ui5-checkbox> 
```


Now
```ts
@Component({
  selector: 'ui5-checkbox',
})
export class CheckboxComponent {
  @Input({ transform: booleanAttribute }) disabled!: boolean;
}
```

```html
  <!-- Working now -->
<ui5-checkbox disabled></ui5-checkbox>
```

Fixes: https://github.com/SAP/ui5-webcomponents-ngx/issues/128