### PR TITLE
chore: add '@ui5/theming-ngx'  dependency always

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,13 +67,14 @@ Every form-capable component can be used with Angular's native form approaches. 
 
 ## Versions
 
-The table shows
+The table shows for each `@ui5/webcomponents-ngx` version:
 - the `Angular` compatible version
-- the `@ui5/webcomponents` version that `@ui5/webcomponents-ngx` is built upon and .
+- the `@ui5/webcomponents` compatible version
 
 |@ui5/webcomponents-ngx| Angular  |@ui5/webcomponents|
 |----------------------|----------|------------------|
-|0.3.2                 | 16 & 17  | 1.9.x            |
+|0.2                   | 16       | 1.9.x            |
+|0.3.x                 | 17       | 2.0.x            |
 
 
 ## Support, Feedback, Contributing

--- a/apps/documentation/src/app/stories/main/daterangepicker.stories.ts
+++ b/apps/documentation/src/app/stories/main/daterangepicker.stories.ts
@@ -5,13 +5,22 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The DateRangePicker enables the users to enter a localized date range using touch, mouse, keyboard input, or by selecting a date range in the calendar.
+const description = `
+### Overview
 
-<h3>Usage</h3> The user can enter a date by: Using the calendar that opens in a popup or typing it in directly in the input field (not available for mobile devices). For the <code>ui5-daterange-picker</code> <h3>ES6 Module Import</h3>
+The DateRangePicker enables the users to enter a localized date range using touch, mouse, keyboard input, or by selecting a date range in the calendar.
+
+### Usage
+
+The user can enter a date by: Using the calendar that opens in a popup or typing it in directly in the input field (not available for mobile devices). For the <code>ui5-daterange-picker</code>
+
+### ES6 Module Import
 
 <code>import { DateRangePickerComponent } from "@ui5/webcomponents-ngx/main/date-range-picker";</code>
 
-<h3>Keyboard Handling</h3> The <code>ui5-daterange-picker</code> provides advanced keyboard handling. <br>
+### Keyboard Handling
+
+The <code>ui5-daterange-picker</code> provides advanced keyboard handling. <br>
 
 When the <code>ui5-daterange-picker</code> input field is focused the user can increment or decrement respectively the range start or end date, depending on where the cursor is. The following shortcuts are available: <br> <ul> <li>[PAGEDOWN] - Decrements the corresponding day of the month by one</li> <li>[SHIFT] + [PAGEDOWN] - Decrements the corresponding month by one</li> <li>[SHIFT] + [CTRL] + [PAGEDOWN] - Decrements the corresponding year by one</li> <li>[PAGEUP] - Increments the corresponding day of the month by one</li> <li>[SHIFT] + [PAGEUP] - Increments the corresponding month by one</li> <li>[SHIFT] + [CTRL] + [PAGEUP] - Increments the corresponding year by one</li> </ul>`;
 export default {

--- a/apps/documentation/src/app/stories/main/datetimepicker.stories.ts
+++ b/apps/documentation/src/app/stories/main/datetimepicker.stories.ts
@@ -5,15 +5,18 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The <code>DateTimePicker</code> component alows users to select both date (day, month and year) and time (hours, minutes and seconds) and for the purpose it consists of input field and Date/Time picker.
+const description = `
+### Overview
 
-<h3>Usage</h3>
+The <code>DateTimePicker</code> component alows users to select both date (day, month and year) and time (hours, minutes and seconds) and for the purpose it consists of input field and Date/Time picker.
+
+### Usage
 
 Use the <code>DateTimePicker</code> if you need a combined date and time input component. Don't use it if you want to use either date, or time value. In this case, use the <code>DatePicker</code> or the <code>TimePicker</code> components instead. <br><br> The user can set date/time by: <ul> <li>using the calendar and the time selectors</li> <li>typing in the input field</li> </ul>
 
 Programmatically, to set date/time for the <code>DateTimePicker</code>, use the <code>value</code> property
 
-<h3>Formatting</h3>
+### Formatting
 
 The value entered by typing into the input field must fit to the used date/time format. <br><br> Supported format options are pattern-based on Unicode LDML Date Format notation. For more information, see <ui5-link target="_blank" href="https://unicode.org/reports/tr35/tr35-dates.html#Date_Field_Symbol_Table" class="api-table-content-cell-link">UTS #35: Unicode Locale Data Markup Language</ui5-link>. <br><br> <b>Example:</b> the following format <code>dd/MM/yyyy, hh:mm:ss aa</code> corresponds the <code>13/04/2020, 03:16:16 AM</code> value. <br> The small 'h' defines "12" hours format and the "aa" symbols - "AM/PM" time periods.
 
@@ -25,11 +28,11 @@ The value entered by typing into the input field must fit to the used date/time 
 
 <br><br> <b>Note:</b> If the user input does NOT match the <code>formatPattern</code>, the <code>DateTimePicker</code> makes an attempt to parse it based on the locale settings.
 
-<h3>Responsive behavior</h3>
+### Responsive behavior
 
 The <code>DateTimePicker</code> is responsive and fully adapts to all devices. For larger screens, such as tablet or desktop, it is displayed as a popover, while on phone devices, it is displayed full screen.
 
-<h3>ES6 Module Import</h3>
+### ES6 Module Import
 
 <code>import { DateTimePickerComponent } from "@ui5/webcomponents-ngx/main/date-time-picker";</code>`;
 export default {

--- a/apps/documentation/src/app/stories/main/link.stories.ts
+++ b/apps/documentation/src/app/stories/main/link.stories.ts
@@ -2,17 +2,20 @@ import { Meta, Story, moduleMetadata } from '@storybook/angular';
 import { Ui5WebcomponentsModule, LinkComponent } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The <code>ui5-link</code> is a hyperlink component that is used to navigate to other apps and web pages, or to trigger actions. It is a clickable text element, visualized in such a way that it stands out from the standard text. On hover, it changes its style to an underlined text to provide additional feedback to the user.
+const description = `
+### Overview
 
-<h3>Usage</h3>
+The <code>ui5-link</code> is a hyperlink component that is used to navigate to other apps and web pages, or to trigger actions. It is a clickable text element, visualized in such a way that it stands out from the standard text. On hover, it changes its style to an underlined text to provide additional feedback to the user.
+
+### Usage
 
 You can set the <code>ui5-link</code> to be enabled or disabled. <br><br> To create a visual hierarchy in large lists of links, you can set the less important links as <code>Subtle</code> or the more important ones as <code>Emphasized</code>, by using the <code>design</code> property. <br><br> If the <code>href</code> property is set, the link behaves as the HTML anchor tag (<code>&lt;a&gt;&lt;a&#47;&gt;</code>) and opens the specified URL in the given target frame (<code>target</code> property). To specify where the linked content is opened, you can use the <code>target</code> property.
 
-<h3>Responsive behavior</h3>
+### Responsive behavior
 
 If there is not enough space, the text of the <code>ui5-link</code> becomes truncated. If the <code>wrappingType</code> property is set to <code>"Normal"</code>, the text is displayed on several lines instead of being truncated.
 
-<h3>ES6 Module Import</h3>
+### ES6 Module Import
 
 <code>import { LinkComponent } from "@ui5/webcomponents-ngx/main/link";</code>`;
 export default {

--- a/apps/documentation/src/app/stories/main/progressindicator.stories.ts
+++ b/apps/documentation/src/app/stories/main/progressindicator.stories.ts
@@ -5,11 +5,16 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview Shows the progress of a process in a graphical way. To indicate the progress, the inside of the component is filled with a color.
+const description = `
+### Overview
 
-<h3>Responsive Behavior</h3> You can change the size of the Progress Indicator by changing its <code>width</code> or <code>height</code> CSS properties.
+Shows the progress of a process in a graphical way. To indicate the progress, the inside of the component is filled with a color.
 
-<h3>ES6 Module Import</h3>
+### Responsive Behavior
+
+You can change the size of the Progress Indicator by changing its <code>width</code> or <code>height</code> CSS properties.
+
+### ES6 Module Import
 
 <code>import { ProgressIndicatorComponent } from "@ui5/webcomponents-ngx/main/progress-indicator";</code>`;
 export default {

--- a/apps/documentation/src/app/stories/main/rangeslider.stories.ts
+++ b/apps/documentation/src/app/stories/main/rangeslider.stories.ts
@@ -6,15 +6,15 @@ import {
 import { extractArgTypes } from '../../arg-type-tools';
 
 const description = `
-### Overview 
+### Overview
 
 Represents a numerical interval and two handles (grips) to select a sub-range within it. The purpose of the component to enable visual selection of sub-ranges within a given interval.
 
-### Structure 
+### Structure
 
 The most important properties of the Range Slider are: <ul> <li>min - The minimum value of the slider range.</li> <li>max - The maximum value of the slider range.</li> <li>value - The current value of the slider.</li> <li>step - Determines the increments in which the slider will move.</li> <li>showTooltip - Determines if a tooltip should be displayed above the handle.</li> <li>showTickmarks - Displays a visual divider between the step values.</li> <li>labelInterval - Labels some or all of the tickmarks with their values.</li> </ul> <h4>Notes:</h4> <ul> <li>The right and left handle can be moved individually and their positions could therefore switch.</li> <li>The entire range can be moved along the interval.</li> </ul> ### Usage The most common use case is to select and move sub-ranges on a continuous numerical scale.
 
-### Responsive Behavior 
+### Responsive Behavior
 
 You can move the currently selected range by clicking on it and dragging it along the interval.
 

--- a/apps/documentation/src/app/stories/main/ratingindicator.stories.ts
+++ b/apps/documentation/src/app/stories/main/ratingindicator.stories.ts
@@ -6,25 +6,25 @@ import {
 import { extractArgTypes } from '../../arg-type-tools';
 
 const description = `
-### Overview 
+### Overview
 
 The Rating Indicator is used to display a specific number of icons that are used to rate an item. Additionally, it is also used to display the average and overall ratings.
 
-### Usage</h3> 
+### Usage
 
 The recommended number of icons is between 5 and 7.
 
-### Responsive Behavior</h3> 
+### Responsive Behavior
 
 You can change the size of the Rating Indicator by changing its <code>font-size</code> CSS property. <br> Example: <code>&lt;ui5-rating-indicator style="font-size: 3rem;">&lt;/ui5-rating-indicator></code>
 
-### Keyboard Handling</h3> 
+### Keyboard Handling
 
 When the <code>ui5-rating-indicator</code> is focused, the user can change the rating with the following keyboard shortcuts: <br>
 
 <ul> <li>[RIGHT/UP] - Increases the value of the rating by one step. If the highest value is reached, does nothing</li> <li>[LEFT/DOWN] - Decreases the value of the rating by one step. If the lowest value is reached, does nothing.</li> <li>[HOME] - Sets the lowest value.</li> <li>[END] - Sets the highest value.</li> <li>[SPACE/ENTER/RETURN] - Increases the value of the rating by one step. If the highest value is reached, sets the rating to the lowest value.</li> <li>Any number - Changes value to the corresponding number. If typed number is larger than the number of values, sets the highest value.</li> </ul>
 
-### ES6 Module Import</h3>
+### ES6 Module Import
 
 <code>import { RatingIndicatorComponent } from "@ui5/webcomponents-ngx/main/rating-indicator";</code>`;
 export default {

--- a/apps/documentation/src/app/stories/main/responsivepopover.stories.ts
+++ b/apps/documentation/src/app/stories/main/responsivepopover.stories.ts
@@ -6,11 +6,11 @@ import {
 import { extractArgTypes } from '../../arg-type-tools';
 
 const description = `
-### Overview 
+### Overview
 
 The <code>ui5-responsive-popover</code> acts as a Popover on desktop and tablet, while on phone it acts as a Dialog. The component improves tremendously the user experience on mobile.
 
-### Usage 
+### Usage
 
 Use it when you want to make sure that all the content is visible on any device.
 

--- a/apps/documentation/src/app/stories/main/select.stories.ts
+++ b/apps/documentation/src/app/stories/main/select.stories.ts
@@ -5,11 +5,18 @@ import {
 } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The <code>ui5-select</code> component is used to create a drop-down list. The items inside the <code>ui5-select</code> define the available options by using the <code>ui5-option</code> component.
+const description = `
+### Overview 
 
-<h3>Keyboard Handling</h3> The <code>ui5-select</code> provides advanced keyboard handling. <br> <ul> <li>[F4, ALT+UP, ALT+DOWN, SPACE, ENTER] - Opens/closes the drop-down.</li> <li>[UP, DOWN] - If the drop-down is closed - changes selection to the next or the previous option. If the drop-down is opened - moves focus to the next or the previous option.</li> <li>[SPACE, ENTER] - If the drop-down is opened - selects the focused option.</li> <li>[ESC] - Closes the drop-down without changing the selection.</li> <li>[HOME] - Navigates to first option</li> <li>[END] - Navigates to the last option</li> </ul> <br>
+The <code>ui5-select</code> component is used to create a drop-down list. The items inside the <code>ui5-select</code> define the available options by using the <code>ui5-option</code> component.
 
-<h3>ES6 Module Import</h3> <code>import { SelectComponent } from "@ui5/webcomponents-ngx/main/select";</code> (comes with <code>ui5-select</code>)`;
+### Keyboard Handling
+
+The <code>ui5-select</code> provides advanced keyboard handling. <br> <ul> <li>[F4, ALT+UP, ALT+DOWN, SPACE, ENTER] - Opens/closes the drop-down.</li> <li>[UP, DOWN] - If the drop-down is closed - changes selection to the next or the previous option. If the drop-down is opened - moves focus to the next or the previous option.</li> <li>[SPACE, ENTER] - If the drop-down is opened - selects the focused option.</li> <li>[ESC] - Closes the drop-down without changing the selection.</li> <li>[HOME] - Navigates to first option</li> <li>[END] - Navigates to the last option</li> </ul> <br>
+
+### ES6 Module Import 
+
+<code>import { SelectComponent } from "@ui5/webcomponents-ngx/main/select";</code> (comes with <code>ui5-select</code>)`;
 export default {
   title: 'UI5 Web Components / Main / Select',
   component: SelectComponent,

--- a/apps/documentation/src/app/stories/main/tree.stories.ts
+++ b/apps/documentation/src/app/stories/main/tree.stories.ts
@@ -2,21 +2,26 @@ import { Meta, Story, moduleMetadata } from '@storybook/angular';
 import { Ui5WebcomponentsModule, TreeComponent } from '@ui5/webcomponents-ngx';
 import { extractArgTypes } from '../../arg-type-tools';
 
-const description = `### Overview The <code>ui5-tree</code> component provides a tree structure for displaying data in a hierarchy.
+const description = `
+### Overview
 
-<h3>Usage</h3>
+The <code>ui5-tree</code> component provides a tree structure for displaying data in a hierarchy.
+
+### Usage
 
 <h4>When to use:</h4> <ul> <li>To display hierarchically structured items.</li> <li>To select one or more items out of a set of hierarchically structured items.</li> </ul>
 
 <h4>When not to use:</h4> <ul> <li>To display items not hierarchically strcutured. In this case, use the List component.</li> <li>To select one item from a very small number of non-hierarchical items. Select or ComboBox might be more appropriate.</li> <li>The hierarchy turns out to have only two levels. In this case, use List with group items.</li> </ul>
 
-<h3>Keyboard Handling</h3>
+### Keyboard Handling
 
 The <code>ui5-tree</code> provides advanced keyboard handling. The user can use the following keyboard shortcuts in order to navigate trough the tree: <ul> <li>[UP/DOWN] - Navigates up and down the tree items that are currently visible.</li> <li>[RIGHT] - Drills down the tree by expanding the tree nodes.</li> <li>[LEFT] - Goes up the tree and collapses the tree nodes.</li> </ul> <br>
 
 The user can use the following keyboard shortcuts to perform selection, when the <code>mode</code> property is in use: <ul> <li>[SPACE] - Selects the currently focused item upon keyup.</li> <li>[ENTER] - Selects the currently focused item upon keydown.</li> </ul>
 
-<h3>ES6 Module Import</h3> <code>import { TreeComponent } from "@ui5/webcomponents-ngx/main/tree";</code>`;
+### ES6 Module Import
+
+<code>import { TreeComponent } from "@ui5/webcomponents-ngx/main/tree";</code>`;
 export default {
   title: 'UI5 Web Components / Main / Tree',
   component: TreeComponent,

--- a/libs/angular-generator/src/lib/schematics/common-schematics/add-dependencies/index.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/add-dependencies/index.ts
@@ -16,7 +16,7 @@ export function addDependencies(options: Schema): Rule {
       addPackageToPackageJson(tree, commonCssPackageName, 'latest');
     }
 
-    if (options.theming && !getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
+    if (!getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
       addPackageToPackageJson(tree, themingNgxPackageName, packageJson.version);
     }
 

--- a/libs/angular-generator/src/lib/schematics/common-schematics/add-theming/index.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/add-theming/index.ts
@@ -8,10 +8,6 @@ import { getProjectDefinition } from "../utils/get-project-definition";
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
     updateWorkspace(async (workspace) => {
-      if (!options.theming) {
-        return;
-      }
-
       const projectDefinition = getProjectDefinition(workspace, options.project);
 
       const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);

--- a/libs/angular-generator/src/lib/schematics/common-schematics/get-config.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/get-config.ts
@@ -5,6 +5,7 @@ import { askQuestion } from './utils/promt';
 export async function collectConfig(): Promise<Partial<Schema>> {
   const schema: Partial<Schema> = {
     commonCss: [],
+    theming: true,
     defaultTheme: 'sap_horizon'
   };
 
@@ -12,12 +13,6 @@ export async function collectConfig(): Promise<Partial<Schema>> {
 
   if (includeCommonCss) {
     schema.commonCss = await askCommonCssParts();
-  }
-
-  schema.theming = await askThemingDependency();
-
-  if (schema.theming) {
-    schema.defaultTheme = await askDefaultTheme();
   }
 
   return schema;
@@ -39,20 +34,3 @@ async function askCommonCssParts(): Promise<string[]> {
   });
 }
 
-async function askThemingDependency(): Promise<boolean> {
-  return await askQuestion({
-    type: 'confirm',
-    message:
-      'Would you like to add Theming capabilities into your application?',
-    default: true,
-  });
-}
-
-async function askDefaultTheme(): Promise<string> {
-  return await askQuestion({
-    type: 'list',
-    message: 'Please select desired Common CSS features',
-    default: 'sap_horizon',
-    choices: AvailableThemes,
-  });
-}

--- a/libs/angular-generator/src/lib/schematics/common-schematics/get-config.ts
+++ b/libs/angular-generator/src/lib/schematics/common-schematics/get-config.ts
@@ -1,4 +1,4 @@
-import { AvailableThemes, CommonCssParts } from "./config";
+import { CommonCssParts } from "./config";
 import { Schema } from "./schema";
 import { askQuestion } from './utils/promt';
 
@@ -33,4 +33,3 @@ async function askCommonCssParts(): Promise<string[]> {
     choices: CommonCssParts,
   });
 }
-

--- a/libs/fundamental-styles/schematics/add-dependencies/index.ts
+++ b/libs/fundamental-styles/schematics/add-dependencies/index.ts
@@ -16,7 +16,7 @@ export function addDependencies(options: Schema): Rule {
       addPackageToPackageJson(tree, commonCssPackageName, 'latest');
     }
 
-    if (options.theming && !getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
+    if (!getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
       addPackageToPackageJson(tree, themingNgxPackageName, packageJson.version);
     }
 

--- a/libs/fundamental-styles/schematics/add-theming/index.ts
+++ b/libs/fundamental-styles/schematics/add-theming/index.ts
@@ -8,10 +8,6 @@ import { getProjectDefinition } from "../utils/get-project-definition";
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
     updateWorkspace(async (workspace) => {
-      if (!options.theming) {
-        return;
-      }
-
       const projectDefinition = getProjectDefinition(workspace, options.project);
 
       const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);

--- a/libs/fundamental-styles/schematics/get-config.ts
+++ b/libs/fundamental-styles/schematics/get-config.ts
@@ -5,6 +5,7 @@ import { askQuestion } from './utils/promt';
 export async function collectConfig(): Promise<Partial<Schema>> {
   const schema: Partial<Schema> = {
     commonCss: [],
+    theming: true,
     defaultTheme: 'sap_horizon'
   };
 
@@ -12,12 +13,6 @@ export async function collectConfig(): Promise<Partial<Schema>> {
 
   if (includeCommonCss) {
     schema.commonCss = await askCommonCssParts();
-  }
-
-  schema.theming = await askThemingDependency();
-
-  if (schema.theming) {
-    schema.defaultTheme = await askDefaultTheme();
   }
 
   return schema;
@@ -36,23 +31,5 @@ async function askCommonCssParts(): Promise<string[]> {
     type: 'checkbox',
     message: 'Please select desired Common CSS features',
     choices: CommonCssParts,
-  });
-}
-
-async function askThemingDependency(): Promise<boolean> {
-  return await askQuestion({
-    type: 'confirm',
-    message:
-      'Would you like to add Theming capabilities into your application?',
-    default: true,
-  });
-}
-
-async function askDefaultTheme(): Promise<string> {
-  return await askQuestion({
-    type: 'list',
-    message: 'Please select desired Common CSS features',
-    default: 'sap_horizon',
-    choices: AvailableThemes,
   });
 }

--- a/libs/fundamental-styles/schematics/get-config.ts
+++ b/libs/fundamental-styles/schematics/get-config.ts
@@ -1,4 +1,4 @@
-import { AvailableThemes, CommonCssParts } from "./config";
+import { CommonCssParts } from "./config";
 import { Schema } from "./schema";
 import { askQuestion } from './utils/promt';
 
@@ -33,3 +33,4 @@ async function askCommonCssParts(): Promise<string[]> {
     choices: CommonCssParts,
   });
 }
+

--- a/libs/ui5-angular/README.md
+++ b/libs/ui5-angular/README.md
@@ -24,15 +24,15 @@ import { Ui5WebcomponentsModule } from '@ui5/webcomponents-ngx'; // All componen
 ```
 
 #### Theming
-For using theming, you need to install `@ui5/theming-ngx` package and import the `Ui5ThemingModule` in your app module.
+For using theming, you need import the `Ui5ThemingModule` in your app module.
 
 ```typescript
-import { Ui5ThemingModule } from '@ui5/webcomponents-ngx/theming'; // Theming module import
+import { Ui5WebcomponentsThemingModule } from '@ui5/webcomponents-ngx/theming'; // Theming module import
 
 @NgModule({
   imports: [
     BrowserModule,
-    Ui5ThemingModule.forRoot({defaultTheme: 'sap_horizon'}) // Theming module import
+    Ui5WebcomponentsThemingModule, // Theming module import
   ]
 })
 export class AppModule { }

--- a/libs/ui5-angular/ng-package.json
+++ b/libs/ui5-angular/ng-package.json
@@ -3,5 +3,6 @@
   "dest": "../../dist/libs/ui5-angular",
   "lib": {
     "entryFile": "./index.ts"
-  }
+  },
+  "allowedNonPeerDependencies": ["@ui5/theming-ngx"]
 }

--- a/libs/ui5-angular/package.json
+++ b/libs/ui5-angular/package.json
@@ -31,6 +31,7 @@
     "rxjs": "^6.5.3 || ^7.4.0"
   },
   "dependencies": {
+    "@ui5/theming-ngx": "0.3.0-rc.8",
     "tslib": "^2.4.1"
   },
   "schematics": "./schematics/collection.json",

--- a/libs/ui5-angular/schematics/add-dependencies/index.ts
+++ b/libs/ui5-angular/schematics/add-dependencies/index.ts
@@ -16,7 +16,7 @@ export function addDependencies(options: Schema): Rule {
       addPackageToPackageJson(tree, commonCssPackageName, 'latest');
     }
 
-    if (options.theming && !getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
+    if (!getPackageVersionFromPackageJson(tree, themingNgxPackageName)) {
       addPackageToPackageJson(tree, themingNgxPackageName, packageJson.version);
     }
 

--- a/libs/ui5-angular/schematics/add-theming/index.ts
+++ b/libs/ui5-angular/schematics/add-theming/index.ts
@@ -8,10 +8,6 @@ import { getProjectDefinition } from "../utils/get-project-definition";
 export function addTheming(options: Schema): Rule {
   return (tree, context) =>
     updateWorkspace(async (workspace) => {
-      if (!options.theming) {
-        return;
-      }
-
       const projectDefinition = getProjectDefinition(workspace, options.project);
 
       const update: { changes: Change[], file: string } = addThemingModule(tree, projectDefinition, context, options);

--- a/libs/ui5-angular/schematics/get-config.ts
+++ b/libs/ui5-angular/schematics/get-config.ts
@@ -5,6 +5,7 @@ import { askQuestion } from './utils/promt';
 export async function collectConfig(): Promise<Partial<Schema>> {
   const schema: Partial<Schema> = {
     commonCss: [],
+    theming: true,
     defaultTheme: 'sap_horizon'
   };
 
@@ -12,12 +13,6 @@ export async function collectConfig(): Promise<Partial<Schema>> {
 
   if (includeCommonCss) {
     schema.commonCss = await askCommonCssParts();
-  }
-
-  schema.theming = await askThemingDependency();
-
-  if (schema.theming) {
-    schema.defaultTheme = await askDefaultTheme();
   }
 
   return schema;
@@ -36,23 +31,5 @@ async function askCommonCssParts(): Promise<string[]> {
     type: 'checkbox',
     message: 'Please select desired Common CSS features',
     choices: CommonCssParts,
-  });
-}
-
-async function askThemingDependency(): Promise<boolean> {
-  return await askQuestion({
-    type: 'confirm',
-    message:
-      'Would you like to add Theming capabilities into your application?',
-    default: true,
-  });
-}
-
-async function askDefaultTheme(): Promise<string> {
-  return await askQuestion({
-    type: 'list',
-    message: 'Please select desired Common CSS features',
-    default: 'sap_horizon',
-    choices: AvailableThemes,
   });
 }

--- a/libs/ui5-angular/schematics/get-config.ts
+++ b/libs/ui5-angular/schematics/get-config.ts
@@ -1,4 +1,4 @@
-import { AvailableThemes, CommonCssParts } from "./config";
+import { CommonCssParts } from "./config";
 import { Schema } from "./schema";
 import { askQuestion } from './utils/promt';
 
@@ -33,3 +33,4 @@ async function askCommonCssParts(): Promise<string[]> {
     choices: CommonCssParts,
   });
 }
+


### PR DESCRIPTION
Prior to this PR the `@ui5/theming-ngx` package was missing from the projects dependencies. 

**Issue**
Prior to this PR, 
-  If you get started from scratch with
`ng create my-app`
- And if you install @ui5/webcomponents-ngx with
`npm install @ui5/webcomponents-ngx`,
- And then use some of the components in the app and run the app
`ng serve`
- you will get an error that an import to `@ui5/theming-ngx` could not be resolved
and you need to manually install the `@ui5/theming-ngx` package in addition no matter you want or don't need theming

Most probably it was optimisation effort to exclude the package and only add the dependency if the app requires theming. However, it's not working fine. Even if we use `ng add @ui5/webcomponents-ngx` the user is not asked to install it and the result is the same - we will get an error on `ng serve`.

**Solution**
Add `@ui5/theming-ngx` as dependency unconditionally to avoid breaking on first steps of the usage.

Fixes: https://github.com/SAP/ui5-webcomponents-ngx/issues/62