### PR TITLE
docs: deprecate library, point to Fundamental NGX

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@
 
 # UI5 Web Components for Angular
 
+> [!WARNING]
+> **This library is deprecated and no longer actively maintained.**
+> Please migrate to the Angular web component wrappers available in [Fundamental NGX](https://sap.github.io/fundamental-ngx/#/home), which provides the actively maintained SAP alternative.
+
 ## About this project
 
 This is a wrapper around [@ui5/webcomponents](https://sap.github.io/ui5-webcomponents) project to make it work with

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 > [!WARNING]
 > **This library is deprecated and no longer actively maintained.**
-> Please migrate to the Angular web component wrappers available in [Fundamental NGX](https://sap.github.io/fundamental-ngx/#/home), which provides the actively maintained SAP alternative.
+> Please migrate to the Angular web component wrappers available in [Fundamental NGX](https://sap.github.io/fundamental-ngx/#/home), which provide the actively maintained SAP alternative.
 
 ## About this project
 


### PR DESCRIPTION
## Related Issue(s)

closes none

## Description

- Deprecates library
- Points to Fundamental NGX wrappers as an alternative.

## Screenshots

<!-- If you've made any style changes, please provide appropriate screenshots (before and after) to help reviewers. -->

### Before:

### After:

## PR Quality

-   [ ] the commit message(s) follows the guideline:
        https://github.com/SAP/ui5-webcomponents-ngx/blob/main/CONTRIBUTING.md
-   [ ] tests for the changes that have been done
-   [ ] all items on the PR Review Checklist are addressed :
        https://github.com/SAP/ui5-webcomponents-ngx/wiki/PR-Review-Checklist
-   [ ] Run npm run build-pack-library and test in external application
-   [ ] update `README.md`
-   [ ] [Breaking Changes Wiki](https://github.com/SAP/ui5-webcomponents-ngx/wiki/Breaking-Changes)