### PR TITLE
chore(ci): use GitHub Environments for secret protection

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -22,6 +22,7 @@ jobs:
   create-release:
     name: Create release
     runs-on: ubuntu-latest
+    environment: production
     steps:
       - name: Fetch from origin repo
         uses: actions/checkout@v4.2.2

--- a/.github/workflows/on-pull.yml
+++ b/.github/workflows/on-pull.yml
@@ -12,8 +12,6 @@ concurrency:
 
 env:
   NX_BRANCH: ${{ github.event.number || github.ref_name }}
-  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
-  NX_CLOUD_AUTH_TOKEN: ${{ secrets.NX_CLOUD_AUTH_TOKEN }}
 
 jobs:
     build:


### PR DESCRIPTION
- Add production environment to create-release workflow
- Remove NX_CLOUD_AUTH_TOKEN from on-pull workflow (not needed for PR checks)
- Satisfies SAP OSPO security requirement for environment-protected secrets"
