### PR TITLE
chore: replace long-lived PAT with GITHUB_TOKEN in release workflow

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -24,12 +24,16 @@ jobs:
     runs-on: ubuntu-latest
     environment: production
     steps:
+      # Use GITHUB_TOKEN instead of long-lived PAT for security:
+      # - Short-lived token (expires after workflow run)
+      # - Automatically scoped to this repository
+      # - No manual secret rotation needed
       - name: Fetch from origin repo
         uses: actions/checkout@v4.2.2
         with:
           ref: ${{ fromJSON('["tmp_hotfix_branch", "main"]')[env.IS_HOTFIX] }}
           fetch-depth: 0
-          token: ${{ secrets.GH_TOKEN }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up git user
         run: |


### PR DESCRIPTION
## Summary
Replaces the long-lived Personal Access Token (`GH_TOKEN`) with GitHub's built-in short-lived `GITHUB_TOKEN` in the `create-release.yml` workflow to improve security posture and comply with SAP OSPO security recommendations.

### What Changed

- Security: Replaced secrets.GH_TOKEN with secrets.GITHUB_TOKEN in the checkout step
- Documentation: Added inline comments explaining the security benefits

### Why This Matters
Before: The workflow used a long-lived PAT that:

- ⚠️ Could remain valid for months/years if leaked
- ⚠️ Required manual rotation and secret management
- ⚠️ Had broader potential scope than needed

After: The workflow now uses `GITHUB_TOKEN` which:

- ✅ Expires automatically after the workflow run (~60 minutes)
- ✅ Is scoped only to this repository
- ✅ Requires no manual secret management or rotation
- ✅ Drastically limits blast radius of potential leaks

### Technical Details
The built-in `GITHUB_TOKEN` has sufficient permissions for all operations in this workflow:

- Push commits and tags (lines 79, 99)
- Delete branches (line 103)
- Create releases (lines 85-90)
- The workflow already declares permissions: contents: write, which grants these capabilities to GITHUB_TOKEN.

### OSPO Compliance
This change addresses the OSPO security recommendation: "Reduce Long-Lived Secrets"

_"A leaked long-lived secret can stay valid for months and is hard to detect. OIDC tokens are valid for only a few minutes and are bound to a specific workflow and branch, drastically limiting the blast radius of a leak."_

Note: This workflow already uses OIDC for npm publishing (lines 63-75), which is the recommended approach for external authentication.

### Testing

-  Trigger workflow via manual dispatch
-  Verify successful commit push
-  Verify successful tag creation
-  Verify successful npm publishing
-  Verify successful GitHub release creation
-  (For hotfix scenarios) Verify branch deletion works

### Post-Merge Actions
After confirming the workflow runs successfully with GITHUB_TOKEN:

- Navigate to: Settings → Secrets and variables → Actions
- Delete the GH_TOKEN secret (no longer needed)
- Optionally revoke the associated PAT in GitHub user settings